### PR TITLE
Automatically acquire correct version number from `__init__`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 setup(
     name="dynesty",
     url="https://github.com/joshspeagle/dynesty",
-    version="0.8.2",
+    version="0.8.3",
     author="Josh Speagle",
     author_email="jspeagle@cfa.harvard.edu",
     packages=["dynesty"],

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,18 @@ except ImportError:
     from distutils.core import setup
     setup
 
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+init_string = open(os.path.join(dir_path, 'dynesty', '__init__.py')).read()
+VERS = r"^__version__ = ['\"]([^'\"]*)['\"]"
+mo = re.search(VERS, init_string, re.M)
+__version__ = mo.group(1)
+
     
 setup(
     name="dynesty",
     url="https://github.com/joshspeagle/dynesty",
-    version="0.8.3",
+    version=__version__,
     author="Josh Speagle",
     author_email="jspeagle@cfa.harvard.edu",
     packages=["dynesty"],


### PR DESCRIPTION
This makes sure that the setuptools version matches the package version (otherwise there can be problems when installing).