### PR TITLE
DynamicSampler doesnt set self.bootstrap if defined in key-word argum…

### DIFF
--- a/dynesty/dynamicsampler.py
+++ b/dynesty/dynamicsampler.py
@@ -407,6 +407,8 @@ class DynamicSampler(object):
                 self.bootstrap = 20
             else:
                 self.bootstrap = 0
+        else:
+            self.bootstrap = kwargs.get('bootstrap')
         if self.bootstrap > 0:
             self.enlarge = kwargs.get('enlarge', 1.0)
         else:


### PR DESCRIPTION
Major Issue:
If "bootstrap" is manually defined as key-word argument in DynamicSampler, throws error from line 401. previous update forgot to set self.bootstrap equal to the passed-in value, and so self.bootstrap is undefined.

Example in Demo 2 notebook: set "bootstrap" to be any value in the first cell under "Dynamic Nested Sampling":

```
dsampler = dynesty.DynamicNestedSampler(loglikelihood, prior_transform, ndim, 
                                        bound='single', sample='unif', bootstrap=0)

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-9-7ae6d7016603> in <module>()
      1 dsampler = dynesty.DynamicNestedSampler(loglikelihood, prior_transform, ndim, 
----> 2                                         bound='single', sample='unif', bootstrap=0)

~/.local/lib/python3.6/site-packages/dynesty/dynesty.py in DynamicNestedSampler(loglikelihood, prior_transform, ndim, bound, sample, update_interval, first_update, npdim, rstate, queue_size, pool, use_pool, logl_args, logl_kwargs, ptform_args, ptform_kwargs, enlarge, bootstrap, vol_dec, vol_check, walks, facc, slices, **kwargs)
    533     sampler = DynamicSampler(loglike, ptform, npdim,
    534                              bound, sample, update_interval, first_update,
--> 535                              rstate, queue_size, pool, use_pool, kwargs)
    536 
    537     return sampler

~/.local/lib/python3.6/site-packages/dynesty/dynamicsampler.py in __init__(self, loglikelihood, prior_transform, npdim, bound, method, update_interval, first_update, rstate, queue_size, pool, use_pool, kwargs)
    399             else:
    400                 self.bootstrap = 0
--> 401         if self.bootstrap > 0:
    402             self.enlarge = kwargs.get('enlarge', 1.0)
    403         else:

AttributeError: 'DynamicSampler' object has no attribute 'bootstrap'
```