### PR TITLE
Dynamic sampler now updates live points 

### DIFF
--- a/dynesty/__init__.py
+++ b/dynesty/__init__.py
@@ -10,4 +10,4 @@ from . import sampling
 from . import utils
 
 
-__version__ = "0.9.2b"
+__version__ = "0.9.3"

--- a/dynesty/dynamicsampler.py
+++ b/dynesty/dynamicsampler.py
@@ -814,10 +814,6 @@ class DynamicSampler(object):
                                            self.pool, self.use_pool,
                                            self.kwargs)
         self.bound = self.sampler.bound
-        # Keep these in track with the internal sampler
-        self.live_u = self.sampler.live_u
-        self.live_v = self.sampler.live_v
-        self.live_logl = self.sampler.live_logl
 
         # Run the sampler internally as a generator.
         for i in range(1):

--- a/dynesty/dynamicsampler.py
+++ b/dynesty/dynamicsampler.py
@@ -773,6 +773,10 @@ class DynamicSampler(object):
                                            self.pool, self.use_pool,
                                            self.kwargs)
         self.bound = self.sampler.bound
+        # Keep these in track with the internal sampler
+        self.live_u = self.sampler.live_u
+        self.live_v = self.sampler.live_v
+        self.live_logl = self.sampler.live_logl
 
         # Run the sampler internally as a generator.
         for i in range(1):

--- a/dynesty/dynamicsampler.py
+++ b/dynesty/dynamicsampler.py
@@ -1069,9 +1069,9 @@ class DynamicSampler(object):
             # Hack the internal sampler by overwriting the live points
             # and scale factor.
             self.sampler.nlive = nblive
-            self.sampler.live_u = np.array(live_u)
-            self.sampler.live_v = np.array(live_v)
-            self.sampler.live_logl = np.array(live_logl)
+            self.sampler.live_u = self.live_u = np.array(live_u)
+            self.sampler.live_v = self.live_v = np.array(live_v)
+            self.sampler.live_logl = self.live_logl = np.array(live_logl)
             self.sampler.scale = live_scale
 
             # Trigger an update of the internal bounding distribution based
@@ -1107,11 +1107,11 @@ class DynamicSampler(object):
         # Overwrite the previous set of live points in our internal sampler
         # with the new batch of points we just generated.
         self.sampler.nlive = nlive_new
-        self.sampler.live_u = np.array(live_u)
-        self.sampler.live_v = np.array(live_v)
-        self.sampler.live_logl = np.array(live_logl)
-        self.sampler.live_bound = np.array(live_bound)
-        self.sampler.live_it = np.array(live_it)
+        self.sampler.live_u = self.live_u = np.array(live_u)
+        self.sampler.live_v = self.live_v = np.array(live_v)
+        self.sampler.live_logl = self.live_logl = np.array(live_logl)
+        self.sampler.live_bound = self.live_bound = np.array(live_bound)
+        self.sampler.live_it = self.live_it = np.array(live_it)
 
         # Trigger an update of the internal bounding distribution (again).
         loglmin = min(live_logl)


### PR DESCRIPTION
Dynamic sampler previously did not update live_u, live_v, live_logl after the internal sampling began. Now, it assigns those variables to the same arrays as the internal sampler.