### PR TITLE
New implementation of mlfriends

### DIFF
--- a/dynesty/nestedsamplers.py
+++ b/dynesty/nestedsamplers.py
@@ -766,7 +766,10 @@ class RadFriendsSampler(Sampler):
               self).__init__(loglikelihood, prior_transform, npdim,
                              live_points, update_interval, first_update,
                              rstate, queue_size, pool, use_pool)
-        self.radfriends = RadFriends(self.npdim, 0.)
+        if self.kwargs.get('flexiballs', False):
+            self.radfriends = MLFriends(self.npdim, 0.)
+        else:
+            self.radfriends = RadFriends(self.npdim, 0.)
         self.bounding = 'balls'
         self.method = method
         self.use_kdtree = self.kwargs.get('use_kdtree', False)


### PR DESCRIPTION
See issue #121 .


For a simple gaussian likelihood on a unit cube::
```
  scales = np.array([0.1, 0.001, 0.3])
  def loglike(x):
      return -0.5 * (((x - 0.5) / scales)**2).sum()
```

The speed-up from simple scaling is already a factor of 4.

The clustering that detects disjoint ball groups
helps scaling multimodal distributions.
The following likelihood:

```
  scales = np.array([0.1, 0.001, 0.3])
  mu1 = np.array([0.3, 0.2, 0.3])
  mu2 = np.array([0.3, 0.4, 0.3])
  def loglike(x):
      l1 = -0.5 * (((x - mu1) / scales)**2).sum()
      l2 = -0.5 * (((x - mu2) / scales)**2).sum()
      return np.logaddexp(l1, l2)

```
Then sees another factor of 4 increase in efficiency.

The efficiency improvement will be arbitrarily high
when scales[1] is set to lower values.

Reference is https://arxiv.org/abs/1707.04476