### PR TITLE
Map the transformed u value in rwalk, either periodically, or reflect

### DIFF
--- a/dynesty/sampling.py
+++ b/dynesty/sampling.py
@@ -195,6 +195,12 @@ def sample_rwalk(args):
             du = np.dot(axes, dr)
             u_prop = u + scale * du
 
+            # Wrap periodic parameters and reflect non-perioridc parameters
+            u_prop[~nonperiodic] = np.mod(u_prop[~nonperiodic], 1)
+            u_prop_ref = u_prop[nonperiodic]
+            u_prop[nonperiodic] = np.minimum(
+                np.maximum(u_prop_ref, abs(u_prop_ref)), 2 - u_prop_ref)
+
             # Check unit cube constraints.
             if unitcheck(u_prop, nonperiodic):
                 break

--- a/dynesty/sampling.py
+++ b/dynesty/sampling.py
@@ -196,10 +196,11 @@ def sample_rwalk(args):
             u_prop = u + scale * du
 
             # Wrap periodic parameters and reflect non-perioridc parameters
-            u_prop[~nonperiodic] = np.mod(u_prop[~nonperiodic], 1)
-            u_prop_ref = u_prop[nonperiodic]
-            u_prop[nonperiodic] = np.minimum(
-                np.maximum(u_prop_ref, abs(u_prop_ref)), 2 - u_prop_ref)
+            if nonperiodic is not None:
+                u_prop[~nonperiodic] = np.mod(u_prop[~nonperiodic], 1)
+                u_prop_ref = u_prop[nonperiodic]
+                u_prop[nonperiodic] = np.minimum(
+                    np.maximum(u_prop_ref, abs(u_prop_ref)), 2 - u_prop_ref)
 
             # Check unit cube constraints.
             if unitcheck(u_prop, nonperiodic):


### PR DESCRIPTION
This is an initial suggestion for how to close #128. This lets the `u` wander outside the unit cube, then applies the logic to map it back in based on if the parameter is periodic or not. Periodic parameters get wrapped around the unit cube, 1.1 -> 0.1, while reflective (all non-periodic parameters) get reflected, e.g 1.1 -> 0.9. 

This is suggested as a "work in progress", I'd guess it needs implementing in all the other proposal methods so they have similar behaviours, but I thought I'd just put something initial in to see what you thought. This also makes some of the periodic checking code obsolete I think. 