### PR TITLE
For pickling, remove 'rstate' from Sampler state

### DIFF
--- a/dynesty/nestedsamplers.py
+++ b/dynesty/nestedsamplers.py
@@ -547,11 +547,6 @@ class MultiEllipsoidSampler(Sampler):
         self.fmove = self.kwargs.get('fmove', 0.9)
         self.max_move = self.kwargs.get('max_move', 100)
 
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        del state['rstate']
-        return state
-
     def update(self, pointvol):
         """Update the bounding ellipsoids using the current set of
         live points."""

--- a/dynesty/nestedsamplers.py
+++ b/dynesty/nestedsamplers.py
@@ -547,6 +547,11 @@ class MultiEllipsoidSampler(Sampler):
         self.fmove = self.kwargs.get('fmove', 0.9)
         self.max_move = self.kwargs.get('max_move', 100)
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state['rstate']
+        return state
+
     def update(self, pointvol):
         """Update the bounding ellipsoids using the current set of
         live points."""

--- a/dynesty/sampler.py
+++ b/dynesty/sampler.py
@@ -148,6 +148,11 @@ class Sampler(object):
         self.saved_bounditer = []  # active bound at a specific iteration
         self.saved_scale = []  # scale factor at each iteration
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state['rstate']
+        return state
+
     def reset(self):
         """Re-initialize the sampler."""
 


### PR DESCRIPTION
Hi,

We are trying to use Dynesty within the Bilby framework from LIGO, parallelized via MPI.

One issue we hit is that Python 3's built-in pickle module can't pickle "module" objects, and the "Sampler.rstate" object was the numpy.random module:
```
rstate: <class 'module'> <module 'numpy.random' from '/usr/local/lib/python3.7/site-packages/numpy/random/__init__.py'>
```

Now, it's entirely possible this is user error (we're using the simplest Gaussian example in bilby, so not setting rstate explicitly, etc).  It's also possible that this is a horrible idea of how to work around the issue... if one did want to override the rstate, this wouldn't get transmitted to Pool workers...

BUT, this (along with a small patch to bilby) does allow us to run in parallel using MPI!
