### PR TITLE
Travis and Scipy fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,10 @@ python:
     - 2.7
     - 3.6
 
-#before_install:
-#    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-#    - chmod +x miniconda.sh
-#    - ./miniconda.sh -b -p $HOME/miniconda
-#    - export PATH=/home/travis/miniconda/bin:$PATH
-#    - conda update --yes conda
-
 install:
-#    - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
-#    - source activate test
     - pip install -U pip
     - pip install coveralls pyflakes
     - pip install matplotlib==2.2.4
-#    - python setup.py install
     - pip install -e .
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,21 @@ python:
     - 2.7
     - 3.6
 
-before_install:
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b -p $HOME/miniconda
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
+#before_install:
+#    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+#    - chmod +x miniconda.sh
+#    - ./miniconda.sh -b -p $HOME/miniconda
+#    - export PATH=/home/travis/miniconda/bin:$PATH
+#    - conda update --yes conda
 
 install:
-    - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
-    - source activate test
+#    - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
+#    - source activate test
     - pip install -U pip
     - pip install coveralls pyflakes
     - pip install matplotlib==2.2.4
-    - python setup.py install
+#    - python setup.py install
+    - pip install -e .
 
 script: 
     - python runtests.py

--- a/dynesty/dynamicsampler.py
+++ b/dynesty/dynamicsampler.py
@@ -20,7 +20,12 @@ import warnings
 import math
 import numpy as np
 import copy
-from scipy import misc
+import scipy
+if int(scipy.version.version.split('.')[0]) >= 1:
+    from scipy.special import logsumexp
+else:
+    from scipy.misc import logsumexp
+
 
 from .nestedsamplers import (UnitCubeSampler, SingleEllipsoidSampler,
                              MultiEllipsoidSampler, RadFriendsSampler,
@@ -122,10 +127,10 @@ def weight_function(results, args=None, return_weights=False):
     logz_remain = results.logl[-1] + results.logvol[-1]  # remainder
     logz_tot = np.logaddexp(logz[-1], logz_remain)  # estimated upper bound
     lzones = np.ones_like(logz)
-    logzin = misc.logsumexp([lzones * logz_tot, logz], axis=0,
-                            b=[lzones, -lzones])  # ln(remaining evidence)
+    logzin = logsumexp([lzones * logz_tot, logz], axis=0,
+                       b=[lzones, -lzones])  # ln(remaining evidence)
     logzweight = logzin - np.log(results.samples_n)  # ln(evidence weight)
-    logzweight -= misc.logsumexp(logzweight)  # normalize
+    logzweight -= logsumexp(logzweight)  # normalize
     zweight = np.exp(logzweight)  # convert to linear scale
 
     # Derive posterior weights.
@@ -1289,9 +1294,8 @@ class DynamicSampler(object):
         loglstar = -1.e300
         logzvar = 0.
         logvols_pad = np.concatenate(([0.], self.saved_logvol))
-        logdvols = misc.logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
-                                  axis=1, b=np.c_[np.ones(ntot),
-                                                  -np.ones(ntot)])
+        logdvols = logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
+                             axis=1, b=np.c_[np.ones(ntot), -np.ones(ntot)])
         logdvols += math.log(0.5)
         dlvs = logvols_pad[:-1] - logvols_pad[1:]
         for i in range(ntot):

--- a/dynesty/sampler.py
+++ b/dynesty/sampler.py
@@ -15,15 +15,16 @@ import warnings
 import math
 import copy
 import numpy as np
+import scipy
+if int(scipy.version.version.split('.')[0]) >= 1:
+    from scipy.special import logsumexp
+else:
+    from scipy.misc import logsumexp
+
 
 from .results import Results, print_fn
 from .bounding import UnitCube
 from .sampling import sample_unif
-
-try:
-    from scipy.special import logsumexp
-except ImportError:
-    from scipy.misc import logsumexp
 
 __all__ = ["Sampler"]
 

--- a/dynesty/utils.py
+++ b/dynesty/utils.py
@@ -12,7 +12,12 @@ from six.moves import range
 import sys
 import warnings
 import math
-import scipy.misc as misc
+import scipy
+if int(scipy.version.version.split('.')[0]) >= 1:
+    from scipy.special import logsumexp
+else:
+    from scipy.misc import logsumexp
+
 import numpy as np
 import copy
 
@@ -334,9 +339,8 @@ def jitter_run(res, rstate=None, approx=False):
     loglstar = -1.e300
     logzvar = 0.
     logvols_pad = np.concatenate(([0.], logvol))
-    logdvols = misc.logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
-                              axis=1, b=np.c_[np.ones(nsamps),
-                                              -np.ones(nsamps)])
+    logdvols = logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
+                         axis=1, b=np.c_[np.ones(nsamps), -np.ones(nsamps)])
     logdvols += math.log(0.5)
     dlvs = -np.diff(np.append(0., res.logvol))
     saved_logwt, saved_logz, saved_logzvar, saved_h = [], [], [], []
@@ -519,9 +523,8 @@ def resample_run(res, rstate=None, return_idx=False):
     loglstar = -1.e300
     logzvar = 0.
     logvols_pad = np.concatenate(([0.], logvol))
-    logdvols = misc.logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
-                              axis=1, b=np.c_[np.ones(nsamps),
-                                              -np.ones(nsamps)])
+    logdvols = logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
+                         axis=1, b=np.c_[np.ones(nsamps), -np.ones(nsamps)])
     logdvols += math.log(0.5)
     dlvs = logvols_pad[:-1] - logvols_pad[1:]
     saved_logwt, saved_logz, saved_logzvar, saved_h = [], [], [], []
@@ -660,9 +663,8 @@ def reweight_run(res, logp_new, logp_old=None):
     loglstar = -1.e300
     logzvar = 0.
     logvols_pad = np.concatenate(([0.], logvol))
-    logdvols = misc.logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
-                              axis=1, b=np.c_[np.ones(nsamps),
-                                              -np.ones(nsamps)])
+    logdvols = logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
+                         axis=1, b=np.c_[np.ones(nsamps), -np.ones(nsamps)])
     logdvols += math.log(0.5)
     dlvs = -np.diff(np.append(0., logvol))
     saved_logwt, saved_logz, saved_logzvar, saved_h = [], [], [], []
@@ -773,9 +775,8 @@ def unravel_run(res, save_proposals=True, print_progress=True):
         loglstar = -1.e300
         logzvar = 0.
         logvols_pad = np.concatenate(([0.], logvol))
-        logdvols = misc.logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
-                                  axis=1, b=np.c_[np.ones(nsamps),
-                                                  -np.ones(nsamps)])
+        logdvols = logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
+                             axis=1, b=np.c_[np.ones(nsamps), -np.ones(nsamps)])
         logdvols += math.log(0.5)
         dlvs = logvols_pad[:-1] - logvols_pad[1:]
         saved_logwt, saved_logz, saved_logzvar, saved_h = [], [], [], []
@@ -1353,9 +1354,8 @@ def _merge_two(res1, res2, compute_aux=False):
         loglstar = -1.e300
         logzvar = 0.
         logvols_pad = np.concatenate(([0.], combined_logvol))
-        logdvols = misc.logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
-                                  axis=1, b=np.c_[np.ones(ntot),
-                                                  -np.ones(ntot)])
+        logdvols = logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
+                             axis=1, b=np.c_[np.ones(ntot), -np.ones(ntot)])
         logdvols += math.log(0.5)
         dlvs = logvols_pad[:-1] - logvols_pad[1:]
         for i in range(ntot):


### PR DESCRIPTION
Hey Josh,
Numpy updated their latest Scipy version to 1.3.0, which requires python >3.5.  For some reason, under the current .travis.yml, even for the Python2.7 test, travis ends up installing Numpy 1.3.0, which makes it fail.  I edited out a few things that seemed unnecessary for travis (the miniconda lines), which fixes the automated tests.

Then, there was another bug.  Since version 1.0.0, Scipy deprecated scipy.misc.logsumexp(), which was finally removed in version 1.3.0 (the function is located in scipy.special.logsumexp since 0.19.0).  This causes dynesty to break for the latest Scipy version.

If you don't really care about the miniconda setup in the travis file, this PR fixes both of these issues (and passes the tests in both Python 2.7 and 3.6).
