### PR TITLE
Removes the automatic reflective boundaries

### DIFF
--- a/dynesty/sampling.py
+++ b/dynesty/sampling.py
@@ -195,13 +195,9 @@ def sample_rwalk(args):
             du = np.dot(axes, dr)
             u_prop = u + scale * du
 
-            # Wrap periodic parameters and reflect non-perioridc parameters.
+            # Wrap periodic parameters
             if nonperiodic is not None:
                 u_prop[~nonperiodic] = np.mod(u_prop[~nonperiodic], 1)
-                u_prop_ref = u_prop[nonperiodic]
-                u_prop[nonperiodic] = np.minimum(np.maximum(u_prop_ref,
-                                                            abs(u_prop_ref)),
-                                                 2 - u_prop_ref)
 
             # Check unit cube constraints.
             if unitcheck(u_prop, nonperiodic):
@@ -349,13 +345,9 @@ def sample_rstagger(args):
             du = np.dot(axes, dr)
             u_prop = u + scale * stagger * du
 
-            # Wrap periodic parameters and reflect non-perioridc parameters.
+            # Wrap periodic parameters
             if nonperiodic is not None:
                 u_prop[~nonperiodic] = np.mod(u_prop[~nonperiodic], 1)
-                u_prop_ref = u_prop[nonperiodic]
-                u_prop[nonperiodic] = np.minimum(np.maximum(u_prop_ref,
-                                                            abs(u_prop_ref)),
-                                                 2 - u_prop_ref)
 
             # Check unit cube constraints.
             if unitcheck(u_prop, nonperiodic):


### PR DESCRIPTION
In testing using bilby, we found that reflective boundaries can result in odd
behaviour at the boundary. We believe this is because the detailed balance of
the MCMC steps are no longer satisfied (multiple ways exist to get to the same
point). This removes the automated reflective boundaries for
non-periodic parameters (but retains periodic boundaries).