### PR TITLE
remove explicit periodic boundary application

### DIFF
--- a/dynesty/sampling.py
+++ b/dynesty/sampling.py
@@ -195,10 +195,6 @@ def sample_rwalk(args):
             du = np.dot(axes, dr)
             u_prop = u + scale * du
 
-            # Wrap periodic parameters
-            if nonperiodic is not None:
-                u_prop[~nonperiodic] = np.mod(u_prop[~nonperiodic], 1)
-
             # Check unit cube constraints.
             if unitcheck(u_prop, nonperiodic):
                 break
@@ -344,10 +340,6 @@ def sample_rstagger(args):
             # Transform to proposal distribution.
             du = np.dot(axes, dr)
             u_prop = u + scale * stagger * du
-
-            # Wrap periodic parameters
-            if nonperiodic is not None:
-                u_prop[~nonperiodic] = np.mod(u_prop[~nonperiodic], 1)
 
             # Check unit cube constraints.
             if unitcheck(u_prop, nonperiodic):


### PR DESCRIPTION
Hi @joshspeagle, @GregoryAshton and I have been discussing the periodic/reflective boundary situation, I think it has gotten a little confused.

This PR should revert the boundaries to the way it was before https://github.com/joshspeagle/dynesty/pull/129, i.e., users pass a list of "periodic" parameters and the map is then applied by the user. I'm don't think it's possible to achieve this through reversions as part of the changed code was introduced in https://github.com/joshspeagle/dynesty/commit/eb3b313b9881f0ececcfee2bc85887b0fd9d95b0.

Another alternative is to provide a ternary option of `none/periodic/reflective`, but that might be more work to code up and confuse the logic a little more.

We're happy to leave the final decision on implementation up to you, but as far as I can tell the current version (after https://github.com/joshspeagle/dynesty/pull/151) does not allow for reflective boundaries.