### PR TITLE
Allow description markdown to be rendered on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     description=("A dynamic nested sampling package for computing Bayesian "
                  "posteriors and evidences."),
     long_description=long_description,
+    long_description_content_type="text/markdown",
     package_data={"": ["README.md", "LICENSE", "AUTHORS.md"]},
     include_package_data=True,
     install_requires=["numpy", "scipy", "matplotlib", "six"],


### PR DESCRIPTION
This is just a very minor change that will allow the Markdown "Project description" text to be rendered properly on the [PyPI project page](https://pypi.org/project/dynesty/). Obviously not a major issue, but it'll make things look slightly prettier for the next release :wink: 