### PR TITLE
Add an autocorrelation time estimate to rwalk and rstagger

### DIFF
--- a/dynesty/sampler.py
+++ b/dynesty/sampler.py
@@ -324,6 +324,7 @@ class Sampler(object):
         scales = [self.scale for i in range(self.queue_size)]
         ptforms = [self.prior_transform for i in range(self.queue_size)]
         logls = [self.loglikelihood for i in range(self.queue_size)]
+        self.kwargs["live_u"] = self.live_u
         kwargs = [self.kwargs for i in range(self.queue_size)]
         args = zip(point_queue, loglstars, axes_queue,
                    scales, ptforms, logls, kwargs)

--- a/dynesty/sampling.py
+++ b/dynesty/sampling.py
@@ -168,7 +168,8 @@ def sample_rwalk(args):
     nfail = 0
     act = np.inf
     u_list = [u]
-    v = prior_transform(u)
+    v_list = [prior_transform(u)]
+    logl_list = [loglikelihood(v_list[-1])]
     max_walk_warning = True
 
     drhat, dr, du, u_prop, logl_prop = np.nan, np.nan, np.nan, np.nan, np.nan
@@ -213,6 +214,8 @@ def sample_rwalk(args):
         else:
             nfail += 1
             u_list.append(u_list[-1])
+            v_list.append(v_list[-1])
+            logl_list.append(logl_list[-1])
             continue
 
         # Check if we're stuck generating bad numbers.
@@ -231,10 +234,14 @@ def sample_rwalk(args):
             v = v_prop
             logl = logl_prop
             accept += 1
-            u_list.append(u_prop)
+            u_list.append(u)
+            v_list.append(v)
+            logl_list.append(logl)
         else:
             reject += 1
             u_list.append(u_list[-1])
+            v_list.append(v_list[-1])
+            logl_list.append(logl_list[-1])
 
         if accept > walks:
             act = np.max([1, autocorr_new(np.array(u_list).T)])
@@ -258,6 +265,18 @@ def sample_rwalk(args):
 
     blob = {'accept': accept, 'reject': reject, 'fail': nfail, 'scale': scale,
             'u_list': np.array(u_list), 'act': act}
+
+    # If the act is finite, pick randomly from within the chain
+    if np.isfinite(act):
+        idx = np.random.randint(act, len(u_list))
+        u = u_list[idx]
+        v = v_list[idx]
+        logl = logl_list[idx]
+    else:
+        warnings.warn("Returning the last point in the chain")
+        u = u_list[-1]
+        v = v_list[-1]
+        logl = logl_list[-1]
 
     ncall = accept + reject
     return u, v, logl, ncall, blob
@@ -341,7 +360,8 @@ def sample_rstagger(args):
     stagger = 1.  # adaptive scale
     act = np.inf
     u_list = [u]
-    v = prior_transform(u)
+    v_list = [prior_transform(u)]
+    logl_list = [loglikelihood(v_list[-1])]
     max_walk_warning = True
 
     drhat, dr, du, u_prop, logl_prop = np.nan, np.nan, np.nan, np.nan, np.nan
@@ -386,6 +406,8 @@ def sample_rstagger(args):
         else:
             nfail += 1
             u_list.append(u_list[-1])
+            v_list.append(v_list[-1])
+            logl_list.append(logl_list[-1])
             continue
 
         # Check if we're stuck generating bad numbers.
@@ -404,10 +426,14 @@ def sample_rstagger(args):
             v = v_prop
             logl = logl_prop
             accept += 1
-            u_list.append(u_prop)
+            u_list.append(u)
+            v_list.append(v)
+            logl_list.append(logl)
         else:
             reject += 1
             u_list.append(u_list[-1])
+            v_list.append(v_list[-1])
+            logl_list.append(logl_list[-1])
 
         if accept > walks:
             act = np.max([1, autocorr_new(np.array(u_list).T)])
@@ -435,6 +461,18 @@ def sample_rstagger(args):
             warnings.warn("Random walk proposals appear to be "
                           "extremely inefficient. Adjusting the "
                           "scale-factor accordingly.")
+
+    # If the act is finite, pick randomly from within the chain
+    if np.isfinite(act):
+        idx = np.random.randint(act, len(u_list))
+        u = u_list[idx]
+        v = v_list[idx]
+        logl = logl_list[idx]
+    else:
+        warnings.warn("Returning the last point in the chain")
+        u = u_list[-1]
+        v = v_list[-1]
+        logl = logl_list[-1]
 
     blob = {'accept': accept, 'reject': reject, 'fail': nfail, 'scale': scale,
             'u_list': np.array(u_list), 'act': act}

--- a/dynesty/sampling.py
+++ b/dynesty/sampling.py
@@ -263,9 +263,6 @@ def sample_rwalk(args):
                           "extremely inefficient. Adjusting the "
                           "scale-factor accordingly.")
 
-    blob = {'accept': accept, 'reject': reject, 'fail': nfail, 'scale': scale,
-            'u_list': np.array(u_list), 'act': act}
-
     # If the act is finite, pick randomly from within the chain
     if np.isfinite(act):
         idx = np.random.randint(act, len(u_list))
@@ -277,6 +274,8 @@ def sample_rwalk(args):
         u = u_list[-1]
         v = v_list[-1]
         logl = logl_list[-1]
+
+    blob = {'accept': accept, 'reject': reject, 'fail': nfail, 'scale': scale}
 
     ncall = accept + reject
     return u, v, logl, ncall, blob
@@ -474,8 +473,7 @@ def sample_rstagger(args):
         v = v_list[-1]
         logl = logl_list[-1]
 
-    blob = {'accept': accept, 'reject': reject, 'fail': nfail, 'scale': scale,
-            'u_list': np.array(u_list), 'act': act}
+    blob = {'accept': accept, 'reject': reject, 'fail': nfail, 'scale': scale}
 
     ncall = accept + reject
     return u, v, logl, ncall, blob

--- a/dynesty/utils.py
+++ b/dynesty/utils.py
@@ -1423,3 +1423,49 @@ def _merge_two(res1, res2, compute_aux=False):
     res = Results(r)
 
     return res
+
+
+# Automated windowing procedure following Sokal (1989)
+def auto_window(taus, c):
+    m = np.arange(len(taus)) < c * taus
+    if np.any(m):
+        return np.argmin(m)
+    return len(taus) - 1
+
+
+# The following autocorrelation estimates are adapated from Dan Foreman-Mackay: https://dfm.io/posts/autocorr/
+
+
+def autocorr_new(y, c=5.0):
+    f = np.zeros(y.shape[1])
+    for yy in y:
+        f += autocorr_func_1d(yy)
+    f /= len(y)
+    taus = 2.0 * np.cumsum(f) - 1.0
+    window = auto_window(taus, c)
+    return taus[window]
+
+
+def next_pow_two(n):
+    i = 1
+    while i < n:
+        i = i << 1
+    return i
+
+
+def autocorr_func_1d(x, norm=True):
+    x = np.atleast_1d(x)
+    if len(x.shape) != 1:
+        raise ValueError("invalid dimensions for 1D autocorrelation function")
+    n = next_pow_two(len(x))
+
+    # Compute the FFT and then (from that) the auto-correlation function
+    f = np.fft.fft(x - np.mean(x), n=2 * n)
+    acf = np.fft.ifft(f * np.conjugate(f))[:len(x)].real
+    acf /= 4 * n
+
+    # Optionally normalize
+    if norm:
+        acf /= acf[0]
+
+    return acf


### PR DESCRIPTION
- Adds two new tuning parameters to the rwalk and rstagger methods:
  maxmcmc and nact
- maxmcmc controls the maximum number of steps
- nact controls the number of autocorrelation steps to take before
  accepting a point
- the ACT estimate is based on a blob post from Dan Foreman-Mackay
- the walks parameter has the modified meaning of the "minimum" number
  of steps to take