### PR TITLE
getstate support

### DIFF
--- a/dynesty/dynamicsampler.py
+++ b/dynesty/dynamicsampler.py
@@ -459,6 +459,30 @@ class DynamicSampler(object):
         self.new_scale = []
         self.new_logl_min, self.new_logl_max = -np.inf, np.inf  # logl bounds
 
+        def __getstate__(self):
+            """Get state information for pickling."""
+        
+            state = self.__dict__.copy()
+
+            del state['rstate']  # remove random module
+
+            # deal with pool
+            if state['pool'] is not None:
+                del state['pool']  # remove pool
+                del state['M']  # remove `pool.map` function hook
+            
+            # deal with internal sampler (to be safe)
+            if state['sampler'] is not None:
+                try:  # attempt to remove the same things
+                    del state['sampler'].rstate
+                    if state['sampler'].pool is not None:
+                        del state['sampler'].pool
+                        del state['sampler'].M
+                except:
+                    pass
+
+            return state
+
     def reset(self):
         """Re-initialize the sampler."""
 

--- a/dynesty/sampler.py
+++ b/dynesty/sampler.py
@@ -154,8 +154,17 @@ class Sampler(object):
         self.saved_scale = []  # scale factor at each iteration
 
     def __getstate__(self):
+        """Get state information for pickling."""
+        
         state = self.__dict__.copy()
-        del state['rstate']
+        
+        del state['rstate']  # remove random module
+        
+        # deal with pool
+        if state['pool'] is not None:
+            del state['pool']  # remove pool
+            del state['M']  # remove `pool.map` function hook
+            
         return state
 
     def reset(self):


### PR DESCRIPTION
Added in support for pools following #165, and added in a similar functionality for the `dynamicsampler`. That particular one might not work (I didn't test all cases), but since it wasn't even support originally and I'm not pushing it to PyPI yet I'm not too worried about it.