### PR TITLE
__getstate__ has wrong indentation for DynamicSampler

### DIFF
--- a/dynesty/dynamicsampler.py
+++ b/dynesty/dynamicsampler.py
@@ -453,29 +453,29 @@ class DynamicSampler(object):
         self.new_scale = []
         self.new_logl_min, self.new_logl_max = -np.inf, np.inf  # logl bounds
 
-        def __getstate__(self):
-            """Get state information for pickling."""
+    def __getstate__(self):
+        """Get state information for pickling."""
 
-            state = self.__dict__.copy()
+        state = self.__dict__.copy()
 
-            del state['rstate']  # remove random module
+        del state['rstate']  # remove random module
 
-            # deal with pool
-            if state['pool'] is not None:
-                del state['pool']  # remove pool
-                del state['M']  # remove `pool.map` function hook
+        # deal with pool
+        if state['pool'] is not None:
+            del state['pool']  # remove pool
+            del state['M']  # remove `pool.map` function hook
 
-            # deal with internal sampler (to be safe)
-            if state['sampler'] is not None:
-                try:  # attempt to remove the same things
-                    del state['sampler'].rstate
-                    if state['sampler'].pool is not None:
-                        del state['sampler'].pool
-                        del state['sampler'].M
-                except:
-                    pass
+        # deal with internal sampler (to be safe)
+        if state['sampler'] is not None:
+            try:  # attempt to remove the same things
+                del state['sampler'].rstate
+                if state['sampler'].pool is not None:
+                    del state['sampler'].pool
+                    del state['sampler'].M
+            except:
+                pass
 
-            return state
+        return state
 
     def reset(self):
         """Re-initialize the sampler."""


### PR DESCRIPTION
The __getstate__ method of the DynamicSampler wasn't actually being called as it had the wrong indentation and so was being considered a method of the __init__ method. I noticed this when trying to pickle DynamicSampler in the same way we do for the fixed live point samplers here. 

In combination with #188, this makes it a bit easier to save and resume progress. 