### PR TITLE
travis: update numpy to avoid mismatch between numpy and scipy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,16 @@ dist: trusty
 python:
     - 2.7
     - 3.6
+    - 3.7
+    - 3.8
 
 install:
-    - pip install -U pip
+    - pip install -U pip numpy
     - pip install coveralls pyflakes
     - pip install matplotlib==2.2.4
     - pip install -e .
 
-script: 
+script:
     - python runtests.py
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
 
 sudo: False
-dist: trusty
+dist: bionic
 
 python:
-    - 2.7
-    - 3.6
-    - 3.7
-    - 3.8
+  - 2.7
+  - 3.6
+  - 3.7
+  - 3.8
 
 install:
     - pip install -U pip numpy


### PR DESCRIPTION
I also added 3.7 and 3.8 to the matrix since I assumed they are supported and should hence be tested.