### PR TITLE
fixed repeated removing while pickling sampler in sampler.py

### DIFF
--- a/dynesty/sampler.py
+++ b/dynesty/sampler.py
@@ -158,12 +158,17 @@ class Sampler(object):
 
         state = self.__dict__.copy()
 
-        del state['rstate']  # remove random module
+        #attempt to remove from internal sampler, if not dealt within DynamicSampler class
+        try:
+            #remove random module
+            del state['rstate']
 
-        # deal with pool
-        if state['pool'] is not None:
-            del state['pool']  # remove pool
-            del state['M']  # remove `pool.map` function hook
+            # deal with pool
+            if state['pool'] is not None:
+                del state['pool']  # remove pool
+                del state['M']  # remove `pool.map` function hook
+        except:
+            pass
 
         return state
 


### PR DESCRIPTION
It looks like deleting `rstate`, `pool`  and `pool.map` was repeated [here ](https://github.com/joshspeagle/dynesty/blob/265bbe4bf6573704cea9ab4640ebf9e18edcae7f/dynesty/sampler.py#L161) and [here](https://github.com/joshspeagle/dynesty/blob/265bbe4bf6573704cea9ab4640ebf9e18edcae7f/dynesty/dynamicsampler.py#L469). I have added a simple try except statement in sampler.py to overcome this. 