### PR TITLE
move np.int to int

### DIFF
--- a/dynesty/utils.py
+++ b/dynesty/utils.py
@@ -168,7 +168,7 @@ def resample_equal(samples, weights, rstate=None):
     positions = (rstate.random() + np.arange(nsamples)) / nsamples
 
     # Resample the data.
-    idx = np.zeros(nsamples, dtype=np.int)
+    idx = np.zeros(nsamples, dtype=int)
     cumulative_sum = np.cumsum(weights)
     i, j = 0, 0
     while i < nsamples:


### PR DESCRIPTION
`np.int` is due to be deprecated in `numpy` (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)