### PR TITLE
Specify clustering dimensions

### DIFF
--- a/dynesty/dynamicsampler.py
+++ b/dynesty/dynamicsampler.py
@@ -343,11 +343,12 @@ class DynamicSampler(object):
 
     def __init__(self, loglikelihood, prior_transform, npdim,
                  bound, method, update_interval, first_update, rstate,
-                 queue_size, pool, use_pool, kwargs):
+                 queue_size, pool, use_pool, ncdim, kwargs):
         # distributions
         self.loglikelihood = loglikelihood
         self.prior_transform = prior_transform
         self.npdim = npdim
+        self.ncdim = ncdim
 
         # bounding/sampling
         self.bounding = bound
@@ -731,7 +732,7 @@ class DynamicSampler(object):
             maxcall = sys.maxsize
         if maxiter is None:
             maxiter = sys.maxsize
-        if nlive <= 2 * self.npdim:
+        if nlive <= 2 * self.ncdim:
             warnings.warn("Beware: `nlive_init <= 2 * ndim`!")
 
         if not resume:
@@ -828,7 +829,8 @@ class DynamicSampler(object):
                                                first_update,
                                                self.rstate, self.queue_size,
                                                self.pool, self.use_pool,
-                                               self.kwargs)
+                                               ncdim=self.ncdim,
+                                               kwargs=self.kwargs)
             self.bound = self.sampler.bound
 
         # Run the sampler internally as a generator.
@@ -1018,7 +1020,7 @@ class DynamicSampler(object):
             maxcall = sys.maxsize
         if maxiter is None:
             maxiter = sys.maxsize
-        if nlive_new <= 2 * self.npdim:
+        if nlive_new <= 2 * self.ncdim:
             warnings.warn("Beware: `nlive_batch <= 2 * ndim`!")
         self.sampler.save_bounds = save_bounds
 

--- a/dynesty/dynesty.py
+++ b/dynesty/dynesty.py
@@ -587,7 +587,7 @@ def DynamicNestedSampler(loglikelihood, prior_transform, ndim,
                          vol_dec=0.5, vol_check=2.0,
                          walks=25, facc=0.5,
                          slices=5, fmove=0.9, max_move=100,
-                         update_func=None, **kwargs):
+                         update_func=None, ncdim=None, **kwargs):
     """
     Initializes and returns a sampler object for Dynamic Nested Sampling.
 
@@ -796,6 +796,12 @@ def DynamicNestedSampler(loglikelihood, prior_transform, ndim,
         callable function is passed to `sample` but no similar function is
         passed to `update_func`, this will default to no update.
 
+    ncdim: int, optional
+        The number of clustering dimensions. The first ncdim dimensions will
+        be sampled using the sampling method, the remaining dimensions will
+        just sample uniformly from the prior distribution.
+        If this is `None` (default), this will default to npdim.
+
     Returns
     -------
     sampler : a :class:`dynesty.DynamicSampler` instance
@@ -806,6 +812,8 @@ def DynamicNestedSampler(loglikelihood, prior_transform, ndim,
     # Prior dimensions.
     if npdim is None:
         npdim = ndim
+    if ncdim is None:
+        ncdim = npdim
 
     # Bounding method.
     if bound not in _SAMPLERS:
@@ -950,7 +958,7 @@ def DynamicNestedSampler(loglikelihood, prior_transform, ndim,
     # Initialize our nested sampler.
     sampler = DynamicSampler(loglike, ptform, npdim,
                              bound, sample, update_interval, first_update,
-                             rstate, queue_size, pool, use_pool, kwargs)
+                             rstate, queue_size, pool, use_pool, ncdim, kwargs)
 
     return sampler
 

--- a/dynesty/dynesty.py
+++ b/dynesty/dynesty.py
@@ -112,7 +112,7 @@ def NestedSampler(loglikelihood, prior_transform, ndim, nlive=500,
                   compute_jac=False,
                   enlarge=None, bootstrap=0, vol_dec=0.5, vol_check=2.0,
                   walks=25, facc=0.5, slices=5, fmove=0.9, max_move=100,
-                  update_func=None, **kwargs):
+                  update_func=None, ncdim=None, **kwargs):
     """
     Initializes and returns a sampler object for Static Nested Sampling.
 
@@ -335,6 +335,12 @@ def NestedSampler(loglikelihood, prior_transform, ndim, nlive=500,
         callable function is passed to `sample` but no similar function is
         passed to `update_func`, this will default to no update.
 
+    ncdim: int, optional
+        The number of clustering dimensions. The first ncdim dimensions will
+        be sampled using the sampling method, the remaining dimensions will
+        just sample uniformly from the prior distribution.
+        If this is `None` (default), this will default to npdim.
+
     Returns
     -------
     sampler : sampler from :mod:`~dynesty.nestedsamplers`
@@ -345,6 +351,8 @@ def NestedSampler(loglikelihood, prior_transform, ndim, nlive=500,
     # Prior dimensions.
     if npdim is None:
         npdim = ndim
+    if ncdim is None:
+        ncdim = npdim
 
     # Bounding method.
     if bound not in _SAMPLERS:
@@ -561,7 +569,7 @@ def NestedSampler(loglikelihood, prior_transform, ndim, nlive=500,
     sampler = _SAMPLERS[bound](loglike, ptform, npdim,
                                live_points, sample, update_interval,
                                first_update, rstate, queue_size, pool,
-                               use_pool, kwargs)
+                               use_pool, kwargs, ncdim=ncdim)
 
     return sampler
 

--- a/dynesty/nestedsamplers.py
+++ b/dynesty/nestedsamplers.py
@@ -624,7 +624,7 @@ class MultiEllipsoidSampler(Sampler):
             u, idx, q = self.mell.sample(rstate=self.rstate, return_q=True)
 
             # Check if the point is within the unit cube.
-            if unitcheck(u, self.nonbounded):
+            if unitcheck(u, self.nonbounded[:self.ncdim]):
                 # Accept the point with probability 1/q to account for
                 # overlapping ellipsoids.
                 if q == 1 or self.rstate.rand() < 1.0 / q:

--- a/dynesty/sampler.py
+++ b/dynesty/sampler.py
@@ -85,12 +85,13 @@ class Sampler(object):
 
     def __init__(self, loglikelihood, prior_transform, npdim, live_points,
                  update_interval, first_update, rstate,
-                 queue_size, pool, use_pool):
+                 queue_size, pool, use_pool, ncdim):
 
         # distributions
         self.loglikelihood = loglikelihood
         self.prior_transform = prior_transform
         self.npdim = npdim
+        self.ncdim = ncdim
 
         # live points
         self.live_u, self.live_v, self.live_logl = live_points
@@ -132,7 +133,7 @@ class Sampler(object):
         self.since_update = 0  # number of calls since the last update
         self.ncall = self.nlive  # number of function calls
         self.dlv = math.log((self.nlive + 1.) / self.nlive)  # shrinkage/iter
-        self.bound = [UnitCube(self.npdim)]  # bounding distributions
+        self.bound = [UnitCube(self.ncdim)]  # bounding distributions
         self.nbound = 1  # total number of unique bounding distributions
         self.added_live = False  # whether leftover live points were used
         self.eff = 0.  # overall sampling efficiency
@@ -206,7 +207,7 @@ class Sampler(object):
         self.it = 1
         self.since_update = 0
         self.ncall = self.nlive
-        self.bound = [UnitCube(self.npdim)]
+        self.bound = [UnitCube(self.ncdim)]
         self.nbound = 1
         self.added_live = False
 
@@ -340,7 +341,7 @@ class Sampler(object):
             else:
                 # Propose/evaluate points directly from the unit cube.
                 point = self.rstate.rand(self.npdim)
-                axes = np.identity(self.npdim)
+                axes = np.identity(self.ncdim)
                 evolve_point = sample_unif
             point_queue.append(point)
             axes_queue.append(axes)


### PR DESCRIPTION
Hi @joshspeagle, this PR would add a new parameter `ncdim` to specify the number of parameters to do the clustering on. This is distinct from the `npdim` where the nuisance parameters are things that we don't expect to gain much information for, but we are still interested in being able to associate specific sample values with the measured parameters. Adding in the option to not cluster on these parameters makes ellipsoid construction faster/more reliable for the remaining parameters.

I've tested this with `ncdim` set and unset for all of the built-in sampling methods with the multi-ellipsoid sampler and it seems to work well. If you're interested in merging this, I'd be happy to do a quick test with the other samplers.

I've tried to follow the repository style, but let me know if there's anything you'd like to change.