### PR TITLE
fix the volume determination

### DIFF
--- a/dynesty/bounding.py
+++ b/dynesty/bounding.py
@@ -151,11 +151,6 @@ class Ellipsoid(object):
         self.am = lalg.pinvh(cov)  # precision matrix (inverse of covariance)
         self.axes = lalg.cholesky(cov, lower=True)  # transformation axes
 
-        # Volume of ellipsoid is the volume of an n-sphere divided
-        # by the (determinant of the) Jacobian associated with the
-        # transformation, which by definition is the precision matrix.
-        detsign, detln = linalg.slogdet(self.am)
-        self.vol = np.exp(logvol_prefactor(self.n) - 0.5 * detln)
 
         # The eigenvalues (l) of `a` are (a^-2, b^-2, ...) where
         # (a, b, ...) are the lengths of principle axes.
@@ -163,6 +158,9 @@ class Ellipsoid(object):
         l, v = lalg.eigh(self.cov)
         if np.all((l > 0.) & (np.isfinite(l))):
             self.axlens = np.sqrt(l)
+            # Volume of ellipsoid is the volume of an n-sphere 
+            # is a product of squares of eigen values
+            self.vol = np.exp(logvol_prefactor(self.n) + 0.5*np.log(l).sum())
         else:
             raise ValueError("The input precision matrix defining the "
                              "ellipsoid {0} is apparently singular with "


### PR DESCRIPTION
Hi, 

I'm seeing these errors 
```
  /home/skoposov/pyenv38/lib/python3.8/site-packages/dynesty/bounding.py:611: RuntimeWarning: invalid value encountered in double_scalars
  self.expand_tot = self.vol_tot / vol_tot_orig
/home/skoposov/pyenv38/lib/python3.8/site-packages/dynesty/bounding.py:183: RuntimeWarning: invalid value encountered in double_scalars
  f = np.exp((np.log(vol) - np.log(self.vol)) / self.n)  # linear factor
/home/skoposov/pyenv38/lib/python3.8/site-packages/dynesty/bounding.py:401: RuntimeWarning: invalid value encountered in double_scalars
  self.expand_tot *= vol_tot / self.vol_tot
```
Withe following variable values from bounding.py:
self.vol_tot, vol_tot_orig, expands, self.vols
inf inf [1.] [inf]


Digging deeper into this, it could be traced to 
https://github.com/joshspeagle/dynesty/blob/95d43aa483ff0b058ebba4df04961c198f58d0ba/dynesty/bounding.py#L157
where the volume is computed from the slogdet, while the checks are done based on eigen values 

I think the volume needs to be computed based on the eigen values themselves. That is more precise anyway. 
I fix that in the patch.

In the future I think, it's better to store logs of volumes, but that's beyond this patch.

Cheers,
      S