### PR TITLE
add pylint test to the test suite to catch trivial oversights

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,12 @@ python:
 
 install:
     - pip install -U pip numpy
-    - pip install coveralls pyflakes
+    - pip install coveralls pyflakes pylint
     - pip install matplotlib==2.2.4
     - pip install -e .
 
 script:
     - python runtests.py
+    - pylint -E --disable=E1101,E1130  dynesty/*py
 
 after_success: coveralls


### PR DESCRIPTION
To ensure the most obvious errors are caught, I've added pylint to the travis testing. 
