### PR TITLE
decrease the condition number of bounding ellipsoids

### DIFF
--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -1265,7 +1265,7 @@ def randsphere(n, rstate=None):
 
     return xhat
 
-def improve_covar_mat(covar0, ntries=100, max_condition_number=1e14):
+def improve_covar_mat(covar0, ntries=100, max_condition_number=1e12):
     """
     Given the covariance matrix improve it, if it is not invertable
     or eigen values are negative or condition number that is above the limit


### PR DESCRIPTION
Hi, 

In my tests (I'm running fits of tens of thousands fits), I still managed to hit an occasional 'can't construct the ellipse bounding points' error, so I've lowered the threshold condition number when trying to improve the matrix to 1e12 (i.e. 1e6 axis ratio).  That seemed to have solved it for me. 

I hope that won't need more changing... 

 S