### PR TITLE
Saving history of likelihood evaluations

### DIFF
--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -1679,6 +1679,7 @@ class DynamicSampler(object):
         finally:
             if pbar is not None:
                 pbar.close()
+            self.loglikelihood.history_save()
 
     def add_batch(self, nlive=500, wt_function=None, wt_kwargs=None,
                   maxiter=None, maxcall=None, logl_bounds=None,
@@ -1793,6 +1794,7 @@ class DynamicSampler(object):
             finally:
                 if pbar is not None:
                     pbar.close()
+                self.loglikelihood.history_save()
 
             # Combine batch with previous runs.
             self.combine_runs()

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -36,7 +36,7 @@ from .nestedsamplers import (UnitCubeSampler, SingleEllipsoidSampler,
                              MultiEllipsoidSampler, RadFriendsSampler,
                              SupFriendsSampler)
 from .results import Results, print_fn
-from .utils import kld_error
+from .utils import kld_error, LogLikelihood
 
 __all__ = ["DynamicSampler", "weight_function", "stopping_function",
            "_kld_error"]
@@ -389,6 +389,7 @@ class DynamicSampler(object):
             self.M = map
         else:
             self.M = pool.map
+
         self.use_pool = use_pool  # provided flags for when to use the pool
         self.use_pool_ptform = use_pool.get('prior_transform', True)
         self.use_pool_logl = use_pool.get('loglikelihood', True)
@@ -752,12 +753,7 @@ class DynamicSampler(object):
                     else:
                         self.live_v = np.array(list(map(self.prior_transform,
                                                         np.array(self.live_u))))
-                    if self.use_pool_logl:
-                        self.live_logl = np.array(list(self.M(\
-                                self.loglikelihood, np.array(self.live_v))))
-                    else:
-                        self.live_logl = np.array(list(map(self.loglikelihood,
-                                                        np.array(self.live_v))))
+                    self.live_logl = np.array(self.loglikelihood.map(np.array(self.live_v)))
 
                     # Convert all `-np.inf` log-likelihoods to finite large 
                     # numbers. Necessary to keep estimators in our sampler from 

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -590,7 +590,9 @@ def DynamicNestedSampler(loglikelihood, prior_transform, ndim,
                          vol_dec=0.5, vol_check=2.0,
                          walks=25, facc=0.5,
                          slices=5, fmove=0.9, max_move=100,
-                         update_func=None, ncdim=None, **kwargs):
+                         update_func=None, ncdim=None,
+                         save_history=False,
+                         history_filename=None, **kwargs):
     """
     Initializes and returns a sampler object for Dynamic Nested Sampling.
 

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -19,7 +19,7 @@ from .nestedsamplers import (UnitCubeSampler, SingleEllipsoidSampler,
                              MultiEllipsoidSampler, RadFriendsSampler,
                              SupFriendsSampler, _SAMPLING)
 from .dynamicsampler import DynamicSampler
-
+from .utils import LogLikelihood
 __all__ = ["NestedSampler", "DynamicNestedSampler", "_function_wrapper"]
 
 _SAMPLERS = {'none': UnitCubeSampler,
@@ -112,7 +112,9 @@ def NestedSampler(loglikelihood, prior_transform, ndim, nlive=500,
                   compute_jac=False,
                   enlarge=None, bootstrap=0, vol_dec=0.5, vol_check=2.0,
                   walks=25, facc=0.5, slices=5, fmove=0.9, max_move=100,
-                  update_func=None, ncdim=None, **kwargs):
+                  update_func=None, ncdim=None,
+                  save_history=False,
+                  history_filename=None, **kwargs):
     """
     Initializes and returns a sampler object for Static Nested Sampling.
 
@@ -496,8 +498,14 @@ def NestedSampler(loglikelihood, prior_transform, ndim, nlive=500,
     # Wrap functions.
     ptform = _function_wrapper(prior_transform, ptform_args, ptform_kwargs,
                                name='prior_transform')
-    loglike = _function_wrapper(loglikelihood, logl_args, logl_kwargs,
-                                name='loglikelihood')
+    if use_pool.get('loglikelihood') or True:
+        pool_logl = pool
+    else:
+        pool_logl = None
+    loglike = LogLikelihood(_function_wrapper(loglikelihood, logl_args,
+                                              logl_kwargs, name='loglikelihood'), ndim,
+                            save=save_history,
+                            history_filename=history_filename or 'dynesty_logl_history.h5', pool=pool_logl)
 
     # Add in gradient.
     if gradient is not None:
@@ -518,12 +526,7 @@ def NestedSampler(loglikelihood, prior_transform, ndim, nlive=500,
             else:
                 live_v = np.array(list(map(ptform,
                                            np.array(live_u))))
-            if use_pool.get('loglikelihood', True):
-                live_logl = np.array(list(M(loglike,
-                                            np.array(live_v))))  # log-like
-            else:
-                live_logl = np.array(list(map(loglike,
-                                              np.array(live_v))))
+            live_logl = loglike.map(np.array(live_v))  # log-like
             live_points = [live_u, live_v, live_logl]
 
             # Convert all `-np.inf` log-likelihoods to finite large numbers.
@@ -945,8 +948,15 @@ def DynamicNestedSampler(loglikelihood, prior_transform, ndim,
     # Wrap functions.
     ptform = _function_wrapper(prior_transform, ptform_args, ptform_kwargs,
                                name='prior_transform')
-    loglike = _function_wrapper(loglikelihood, logl_args, logl_kwargs,
-                                name='loglikelihood')
+
+    if use_pool.get('loglikelihood') or True:
+        pool_logl = pool
+    else:
+        pool_logl = None
+    loglike = LogLikelihood(_function_wrapper(loglikelihood, logl_args,
+                                              logl_kwargs, name='loglikelihood'),                            ndim, pool=pool_logl,
+                            history_filename=history_filename or 'dynesty_logl_history.h5',
+                            save=save_history)
 
     # Add in gradient.
     if gradient is not None:

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -960,6 +960,7 @@ class Sampler(object):
         finally:
             if pbar is not None:
                 pbar.close()
+            self.loglikelihood.history_save()
 
     def add_final_live(self, print_progress=True, print_func=None):
         """

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -186,14 +186,8 @@ class Sampler(object):
             # Compute the prior transform using the default `map` function.
             self.live_v = np.array(list(map(self.prior_transform,
                                             np.array(self.live_u))))
-        if self.use_pool_logl:
-            # Use the pool to compute the log-likelihoods.
-            self.live_logl = np.array(list(self.M(self.loglikelihood,
-                                                  np.array(self.live_v))))
-        else:
-            # Compute the log-likelihoods using the default `map` function.
-            self.live_logl = np.array(list(map(self.loglikelihood,
-                                               np.array(self.live_v))))
+        self.live_logl = self.loglikelihood.map(np.array(self.live_v))
+
         self.live_bound = np.zeros(self.nlive, dtype='int')
         self.live_it = np.zeros(self.nlive, dtype='int')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 scipy
 matplotlib
 six
+h5py

--- a/tests/test_pathology.py
+++ b/tests/test_pathology.py
@@ -3,6 +3,7 @@ from six.moves import range
 import numpy as np
 from numpy import linalg
 import matplotlib
+
 matplotlib.use('Agg')
 from matplotlib import pyplot as plt  # noqa
 import dynesty  # noqa
@@ -14,19 +15,20 @@ np.random.seed(5647)
 
 nlive = 1000
 printing = False
-alpha = 1e-9
+alpha = 1e-8
 
 
 def loglike(x):
     # this is 1/|x} distribution along the x axis
     # it stops rizing near zero at alpha
     # the second dimension is flat
-    logl =  -np.log(np.maximum(np.abs(x[0]), alpha))
+    logl = -np.log(np.maximum(np.abs(x[0]), alpha))
 
-    noplateau = - 1e-10 * (x**2).sum()
-    # this is to avoid complete plateau 
+    noplateau = -1e-10 * (x**2).sum()
+    # this is to avoid complete plateau
 
     return logl + noplateau
+
 
 def prior_transform(x):
     return x * 2 - 1

--- a/tests/test_saver.py
+++ b/tests/test_saver.py
@@ -1,0 +1,42 @@
+from __future__ import (print_function, division)
+import numpy as np
+import dynesty
+import os
+"""
+Run a series of basic tests to check whether anything huge is broken.
+
+"""
+
+# seed the random number generator
+np.random.seed(5647)
+
+nlive = 100
+printing = False
+
+# EGGBOX
+
+
+# see 1306.2144
+def loglike_egg(x):
+    logl = ((2 + np.cos(x[0] / 2) * np.cos(x[1] / 2))**5)
+    return logl
+
+
+def prior_transform_egg(x):
+    return x * 10 * np.pi
+
+
+def test_ellipsoids():
+    # stress test ellipsoid decompositions
+    ndim = 2
+    fname = 'xx.h5'
+    sampler = dynesty.NestedSampler(loglike_egg,
+                                    prior_transform_egg,
+                                    ndim,
+                                    nlive=nlive,
+                                    bound='multi',
+                                    sample='unif',
+                                    save_history=True,
+                                    history_filename=fname)
+    sampler.run_nested(dlogz=0.1, print_progress=printing)
+    assert (os.path.exists(fname))


### PR DESCRIPTION
Hi,

following earlier discussion, 
I propose a test patch that implements optional saving of all likelihood evaluations (in an hdf5 file).
This is done by wrapping the likelihood function and occasionally dumping things into a file. 

If there are no objections, I can tie a few loose ends, i.e. ensure that the last few calls are not lost and adding some docs. 
 
(on a separate note, the use_pool dictionaries need a set of tests).