### PR TITLE
Update seed functionality (again)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+import numpy as np
+import os
+'''
+Here we setup a common seed for all the tests
+But we also allow to set the seed through DYNESTY_TEST_RANDOMSEED
+environment variable.
+That allows to run long tests by looping over seed value to catch
+potentially rare behaviour
+'''
+
+
+@pytest.fixture(autouse=True)
+def set_seed():
+    kw = 'DYNESTY_TEST_RANDOMSEED'
+    if kw in os.environ:
+        seed = int(os.environ[kw])
+    else:
+        seed = 56432
+    # seed the random number generator
+    np.random.seed(seed)

--- a/tests/test_dyn.py
+++ b/tests/test_dyn.py
@@ -1,16 +1,8 @@
 import numpy as np
 import dynesty
-import pytest
 """
 Run a series of basic tests of the 2d eggbox
 """
-
-
-@pytest.fixture(autouse=True)
-def set_seed():
-    # seed the random number generator
-    np.random.seed(56432)
-
 
 nlive = 100
 printing = False

--- a/tests/test_egg.py
+++ b/tests/test_egg.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 import dynesty
 """
 Run a series of basic tests of the 2d eggbox
@@ -7,13 +6,6 @@ Run a series of basic tests of the 2d eggbox
 
 nlive = 1000
 printing = False
-
-
-@pytest.fixture(autouse=True)
-def set_seed():
-    # seed the random number generator
-    np.random.seed(5647)
-
 
 # EGGBOX
 

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -1,12 +1,6 @@
 import dynesty.bounding as db
 import numpy as np
 import scipy.stats
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def set_seed():
-    np.random.seed(143463473)
 
 
 def test_sample():

--- a/tests/test_gau.py
+++ b/tests/test_gau.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy import linalg
 import numpy.testing as npt
 import matplotlib
-import pytest
 
 matplotlib.use('Agg')
 from matplotlib import pyplot as plt  # noqa
@@ -18,12 +17,6 @@ Run a series of basic tests to check whether anything huge is broken.
 
 nlive = 500
 printing = False
-
-
-@pytest.fixture(autouse=True)
-def set_seed():
-    # seed the random number generator
-    np.random.seed(5647)
 
 
 def bootstrap_tol(results):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,18 +1,11 @@
 import numpy as np
 import dynesty
-import pytest
 """
 Run a series of basic tests changing various things like
 maxcall options and potentially other things
 """
 
 nlive = 100
-
-
-@pytest.fixture(autouse=True)
-def set_seed():
-    # seed the random number generator
-    np.random.seed(56432)
 
 
 def loglike(x):

--- a/tests/test_pathology.py
+++ b/tests/test_pathology.py
@@ -1,17 +1,10 @@
 from __future__ import (print_function, division)
 import numpy as np
 import dynesty
-import pytest
 
 nlive = 1000
 printing = False
 alpha = 1e-8
-
-
-@pytest.fixture(autouse=True)
-def set_seed():
-    # seed the random number generator
-    np.random.seed(5647)
 
 
 def loglike(x):

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -1,18 +1,14 @@
 import numpy as np
 import dynesty
 from scipy.special import erf
-# seed the random number generator
-np.random.seed(5372)
 
 nlive = 100
 printing = True
+win = 10
 
 
 def loglike(x):
     return -0.5 * x[1]**2
-
-
-win = 10
 
 
 def prior_transform(x):

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -6,9 +6,6 @@ Run a series of basic tests to check whether anything huge is broken.
 
 """
 
-# seed the random number generator
-np.random.seed(5647)
-
 nlive = 1000
 printing = False
 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -1,18 +1,11 @@
 import numpy as np
 import dynesty
-import pytest
 """
 Run a series of basic tests testing printing output
 """
 
 nlive = 100
 printing = True
-
-
-@pytest.fixture(autouse=True)
-def set_seed():
-    # seed the random number generator
-    np.random.seed(56432)
 
 
 def loglike(x):

--- a/tests/test_saver.py
+++ b/tests/test_saver.py
@@ -2,22 +2,14 @@ import numpy as np
 import dynesty
 import os
 import multiprocessing as mp
-import pytest
 """
-Run a series of basic tests to check whether saving likelikelihood evals 
+Run a series of basic tests to check whether saving likelikelihood evals
 are broken
 
 """
 
 nlive = 100
 printing = False
-
-
-@pytest.fixture(autouse=True)
-def set_seed():
-    # seed the random number generator
-    np.random.seed(5647)
-
 
 # EGGBOX
 


### PR DESCRIPTION
I've restructured the seed settings in the tests, so now it's centralized in conftest.py 
also now it's possible to run tests with multiple seed values if needed I.e.

```bash
for a in `seq 10 ` ; do 
 env DYNESTY_TEST_RANDOMSEED=$a PYTHONPATH=py:tests:$PYTHONPATH pytest  --full-trace   tests/test_printing.py  ;
 done 
```
This can be useful to catch rare/sporadic errors. While the main tests will still use one single seed.