### PR TITLE
Jitter speed/refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,11 @@ jobs:
           pip install .
       - name: pylint
         run: pylint --fail-under=8 --extension-pkg-whitelist=scipy.special  py/dynesty/*py
-      - name: Test
+      - name: TestWithCov
         # Run coverage only for 3.6
         if: ${{ matrix.python-version == '3.6'}}
         run: pytest --durations=0 --cov=dynesty
+      - name: Test
         if: ${{ matrix.python-version != '3.6'}}
         run: pytest --durations=0
       - name: Coveralls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         run: pylint --fail-under=8 --extension-pkg-whitelist=scipy.special  py/dynesty/*py
       - name: Test
         run: |
-           pytest --cov=dynesty
+           pytest --durations=0 --cov=dynesty
       - name: Coveralls
         if: ${{ success() }}
         run: coveralls --service=github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,13 @@ jobs:
       - name: pylint
         run: pylint --fail-under=8 --extension-pkg-whitelist=scipy.special  py/dynesty/*py
       - name: Test
-        run: |
-           pytest --durations=0 --cov=dynesty
+        # Run coverage only for 3.6
+        if: ${{ matrix.python-version == '3.6'}}
+        run: pytest --durations=0 --cov=dynesty
+        if: ${{ matrix.python-version != '3.6'}}
+        run: pytest --durations=0
       - name: Coveralls
-        if: ${{ success() }}
+        if: ${{ success() && ( matrix.python-version == '3.6') }}
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -500,11 +500,11 @@ def jitter_run(res, rstate=None, approx=False):
     logz = -1.e300
     loglstar = -1.e300
     logzvar = 0.
-    logvols_pad = np.concatenate(([0.], logvol))
-    logdvols = logsumexp(a=np.c_[logvols_pad[:-1], logvols_pad[1:]],
-                         axis=1,
-                         b=np.c_[np.ones(nsamps), -np.ones(nsamps)])
-    logdvols += math.log(0.5)
+    logvol_pad = np.concatenate(([0.], logvol))
+    logdvol = logsumexp(a=np.c_[logvol_pad[:-1], logvol_pad[1:]],
+                        axis=1,
+                        b=np.c_[np.ones(nsamps), -np.ones(nsamps)])
+    logdvol += math.log(0.5)
     dlvs = -np.diff(np.append(0., res.logvol))
     saved_logwt, saved_logz, saved_logzvar, saved_h = (np.empty(nsamps),
                                                        np.empty(nsamps),
@@ -513,12 +513,12 @@ def jitter_run(res, rstate=None, approx=False):
     for i in range(nsamps):
         # TODO: explain maths
         loglstar_new = logl[i]
-        logdvol, dlv = logdvols[i], dlvs[i]
-        logwt = np.logaddexp(loglstar_new, loglstar) + logdvol
+        cur_logdvol, dlv = logdvol[i], dlvs[i]
+        logwt = np.logaddexp(loglstar_new, loglstar) + cur_logdvol
         logz_new = np.logaddexp(logz, logwt)
         lzterm = (math.exp(loglstar - logz_new) * loglstar +
                   math.exp(loglstar_new - logz_new) * loglstar_new)
-        h_new = (math.exp(logdvol) * lzterm + math.exp(logz - logz_new) *
+        h_new = (math.exp(cur_logdvol) * lzterm + math.exp(logz - logz_new) *
                  (h + logz) - logz_new)
         dh = h_new - h
         h = h_new

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -514,8 +514,9 @@ def jitter_run(res, rstate=None, approx=False):
     # These are log((L_i+L_{i_1})*(X_i+1-X_i)/2)
     saved_logwt = np.logaddexp(loglstar_pad[1:], loglstar_pad[:-1]) + logdvol2
     saved_logz = np.logaddexp.accumulate(saved_logwt)
-    dzhlnz = ((np.exp(loglstar_pad[1:] / saved_logz) * loglstar_pad[1:] +
-               np.exp(loglstar_pad[:-1] / saved_logz) * loglstar_pad[:-1]))
+    dzhlnz = ((
+        np.exp(loglstar_pad[1:] - saved_logz + logdvol2) * loglstar_pad[1:] +
+        np.exp(loglstar_pad[:-1] - saved_logz + logdvol2) * loglstar_pad[:-1]))
 
     for i in range(nsamps):
         dlv = dlvs[i]

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -533,7 +533,8 @@ def jitter_run(res, rstate=None, approx=False):
         (np.exp(loglstar_pad[1:] - logzmax + logdvol2) * loglstar_pad[1:] +
          np.exp(loglstar_pad[:-1] - logzmax + logdvol2) * loglstar_pad[:-1]))
     # here we divide the likelihood by zmax to avoid to overflow
-    saved_h = zhlnz / np.exp(saved_logz - logzmax) - saved_logz
+    # print(zhlnz, logzmax, saved_logz)
+    saved_h = zhlnz - logzmax * np.exp(saved_logz - logzmax)
     # changes in h in each step
     dh = np.diff(saved_h, prepend=0)
     # why ??

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -504,8 +504,11 @@ def jitter_run(res, rstate=None, approx=False):
     logdvol = logsumexp(a=np.c_[logvol_pad[:-1], logvol_pad[1:]],
                         axis=1,
                         b=np.c_[np.ones(nsamps), -np.ones(nsamps)])
+    # logdvol is log(delta(volumes)) i.e. log (X_i-X_{i-1}) for the
+    # newly simulated run
     logdvol += math.log(0.5)
     dlvs = -np.diff(np.append(0., res.logvol))
+    # this are delta(log(volumes)) of the run
     saved_logwt, saved_logz, saved_logzvar, saved_h = (np.empty(nsamps),
                                                        np.empty(nsamps),
                                                        np.empty(nsamps),
@@ -515,7 +518,10 @@ def jitter_run(res, rstate=None, approx=False):
         loglstar_new = logl[i]
         cur_logdvol, dlv = logdvol[i], dlvs[i]
         logwt = np.logaddexp(loglstar_new, loglstar) + cur_logdvol
+        # this is log (L_{i+1}+L_i) + log(X_{i+1} - X_{i})
         logz_new = np.logaddexp(logz, logwt)
+        # This implements eqn 16 of Speagle2020
+
         lzterm = (math.exp(loglstar - logz_new) * loglstar +
                   math.exp(loglstar_new - logz_new) * loglstar_new)
         h_new = (math.exp(cur_logdvol) * lzterm + math.exp(logz - logz_new) *

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -502,15 +502,16 @@ def jitter_run(res, rstate=None, approx=False):
     # assuming that logvol0 = 0
     # log(exp(LV_{i})-exp(LV_{i+1})) =
     # = LV{i} + log(1-exp(LV_{i+1}-LV{i}))
-    dlogvs = np.diff(logvol, prepend=0)
-    logdvol = logvol - dlogvs + np.log1p(-np.exp(dlogvs))
+    # = LV_{i+1} - (LV_{i+1} -LV_i) + log(1-exp(LV_{i+1}-LV{i}))
+    dlogvol = np.diff(logvol, prepend=0)
+    logdvol = logvol - dlogvol + np.log1p(-np.exp(dlogvol))
 
     # logdvol is log(delta(volumes)) i.e. log (X_i-X_{i-1}) for the
     # newly simulated run
     logdvol2 = logdvol + math.log(0.5)
     # These are log(1/2(X_(i+1)-X_i))
 
-    dlvs = -np.diff(res.logvol, prepend=0)
+    dlogvol_run = -np.diff(res.logvol, prepend=0)
     # this are delta(log(volumes)) of the run
 
     # These are log((L_i+L_{i_1})*(X_i+1-X_i)/2)
@@ -536,7 +537,7 @@ def jitter_run(res, rstate=None, approx=False):
     # changes in h in each step
     dh = np.diff(saved_h, prepend=0)
     # why ??
-    saved_logzvar = np.sum(dh * dlvs)
+    saved_logzvar = np.sum(dh * dlogvol_run)
 
     # Copy results.
     new_res = Results([item for item in res.items()])

--- a/tests/test_gau.py
+++ b/tests/test_gau.py
@@ -112,8 +112,11 @@ def test_gaussian():
                                     ndim_gau,
                                     nlive=nlive)
     sampler.run_nested(print_progress=printing)
-    # check that jitter works
+    # check that jitter/resample/simulate_run work
+    # for not dynamic sampler
     dyfunc.jitter_run(sampler.results)
+    dyfunc.resample_run(sampler.results)
+    dyfunc.simulate_run(sampler.results)
 
     # add samples
     # check continuation behavior

--- a/tests/test_gau.py
+++ b/tests/test_gau.py
@@ -65,8 +65,9 @@ cov_gau = np.identity(ndim_gau)  # set covariance to identity matrix
 cov_gau[cov_gau == 0] = 0.95  # set off-diagonal terms (strongly correlated)
 cov_inv_gau = linalg.inv(cov_gau)  # precision matrix
 lnorm_gau = -0.5 * (np.log(2 * np.pi) * ndim_gau + np.log(linalg.det(cov_gau)))
-prior_win = 10 # +/- 10 on both sides
+prior_win = 10  # +/- 10 on both sides
 logz_truth_gau = ndim_gau * (-np.log(2 * prior_win))
+
 
 def check_results_gau(results, logz_tol, sig=5):
     mean_tol, cov_tol = bootstrap_tol(results)
@@ -161,19 +162,20 @@ def test_gaussian():
     plt.close()
 
 
-def test_bounding():
+def test_bounding_sample():
     # check various bounding methods
     logz_tol = 1
 
     for bound in ['none', 'single', 'multi', 'balls', 'cubes']:
-        sampler = dynesty.NestedSampler(loglikelihood_gau,
-                                        prior_transform_gau,
-                                        ndim_gau,
-                                        nlive=nlive,
-                                        bound=bound,
-                                        sample='unif')
-        sampler.run_nested(print_progress=printing)
-        check_results_gau(sampler.results, logz_tol)
+        for sample in ['unif', 'rwalk', 'slice', 'rslice', 'rstagger']:
+            sampler = dynesty.NestedSampler(loglikelihood_gau,
+                                            prior_transform_gau,
+                                            ndim_gau,
+                                            nlive=nlive,
+                                            bound=bound,
+                                            sample=sample)
+            sampler.run_nested(print_progress=printing)
+            check_results_gau(sampler.results, logz_tol)
 
 
 def test_bounding_bootstrap():
@@ -188,19 +190,6 @@ def test_bounding_bootstrap():
                                         bound=bound,
                                         sample='unif',
                                         bootstrap=5)
-        sampler.run_nested(print_progress=printing)
-        check_results_gau(sampler.results, logz_tol)
-
-
-def test_sampling():
-    # check various sampling methods
-    logz_tol = 1
-    for sample in ['unif', 'rwalk', 'rstagger', 'slice', 'rslice']:
-        sampler = dynesty.NestedSampler(loglikelihood_gau,
-                                        prior_transform_gau,
-                                        ndim_gau,
-                                        nlive=nlive,
-                                        sample=sample)
         sampler.run_nested(print_progress=printing)
         check_results_gau(sampler.results, logz_tol)
 

--- a/tests/test_pathology.py
+++ b/tests/test_pathology.py
@@ -13,7 +13,7 @@ def loglike(x):
     # the second dimension is flat
     logl = -np.log(np.maximum(np.abs(x[0]), alpha))
 
-    noplateau = -1e-10 * (x**2).sum()
+    noplateau = -1e-8 * (x**2).sum()
     # this is to avoid complete plateau
 
     return logl + noplateau


### PR DESCRIPTION
This in development branch dealing with jitter_run() code. 
It's not yet finished. (it's fully working and could be committed but I plan to work further on this) 
It increases code coverage + add comments. 

And one thing I was trying to understand is the origin of this: 
```
   lzterm = (math.exp(loglstar - logz_new) * loglstar +
                  math.exp(loglstar_new - logz_new) * loglstar_new)
        h_new = (math.exp(cur_logdvol) * lzterm + math.exp(logz - logz_new) *
                 (h + logz) - logz_new)
```
from here https://github.com/segasai/dynesty/blob/e6b2c397859ff0a8aa44ca0586a0c7c4e0ad9f8d/py/dynesty/utils.py#L525

I couldn't find this in your paper and I was wondering if you can unpack/reason about this. 
It seems that lzterm is essentially L_i^2/Z_{i+1} + L_{i+1}^2/Z{i+1} 
I'm not sure I follow where this comes from.

Also, I am not sure I fully understand why the volumes are halved here: 
https://github.com/segasai/dynesty/blob/e6b2c397859ff0a8aa44ca0586a0c7c4e0ad9f8d/py/dynesty/utils.py#L509
Is it purely because of the 1/2 in the Eqn 16 in your paper ? 
