### PR TITLE
fix the logzerr calculation, (make sure it's an array)

### DIFF
--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -537,8 +537,8 @@ def jitter_run(res, rstate=None, approx=False):
     saved_h = zhlnz - logzmax * np.exp(saved_logz - logzmax)
     # changes in h in each step
     dh = np.diff(saved_h, prepend=0)
-    # why ??
-    saved_logzvar = np.sum(dh * dlogvol_run)
+
+    saved_logzvar = np.cumsum(dh * dlogvol_run)
 
     # Copy results.
     new_res = Results([item for item in res.items()])


### PR DESCRIPTION
a tiny fix to previous jitter changes discovered when running demo notebooks