### PR TITLE
remove volume_check & update vol_dec for hierarchical splits

### DIFF
--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -1487,6 +1487,8 @@ def _bounding_ellipsoids(points, ell):
     # then BIC is N*log(V1) + X *k *ln(N)
     # from that we can get the volume decrease condition
     # V1/V0 < exp(-(k-1)*X*ln(N)/N)
+    # The choice of BIC is motivated by Xmeans algo from Pelleg 2000
+    # See also Feroz2008
 
     nparam = (ndim * (ndim + 3)) // 2
     vol_dec1 = np.exp(-nparam * np.log(npoints) / npoints)

--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -1504,7 +1504,7 @@ def _bounding_ellipsoids(points, ell):
     vol_dec2 = np.exp(-nparam * (len(out) - 1) * np.log(npoints) / npoints)
 
     # Only accept the split if the volume decreased significantly
-    if logsumexp([e.logvol for e in out]) < 2 * np.log(vol_dec2) + ell.logvol:
+    if logsumexp([e.logvol for e in out]) < np.log(vol_dec2) + ell.logvol:
         return out
 
     # Otherwise, we are happy with the single bounding ellipsoid.

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -409,7 +409,6 @@ class DynamicSampler(object):
             self.enlarge = kwargs.get('enlarge', 1.0)
         else:
             self.enlarge = kwargs.get('enlarge', 1.25)
-        self.vol_dec = kwargs.get('vol_dec', 0.5)
         self.walks = self.kwargs.get('walks', 25)
         self.slices = self.kwargs.get('slices', 3)
         self.cite = self.kwargs.get('cite')

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -410,7 +410,6 @@ class DynamicSampler(object):
         else:
             self.enlarge = kwargs.get('enlarge', 1.25)
         self.vol_dec = kwargs.get('vol_dec', 0.5)
-        self.vol_check = kwargs.get('vol_check', 2.0)
         self.walks = self.kwargs.get('walks', 25)
         self.slices = self.kwargs.get('slices', 3)
         self.cite = self.kwargs.get('cite')

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -195,8 +195,8 @@ def NestedSampler(loglikelihood,
         When `ndim < 10`, this defaults to `'unif'`.
         When `10 <= ndim <= 20`, this defaults to `'rwalk'`.
         When `ndim > 20`, this defaults to `'hslice'` if a `gradient` is
-        provided and `'slice'` otherwise. `'rstagger'` and `'rslice'`
-        are provided as alternatives for `'rwalk'` and `'slice'`, respectively.
+        provided and `'rslice'` otherwise. `'rstagger'` and `'slice'`
+        are provided as alternatives for `'rwalk'` and `'rslice'`, respectively.
         Default is `'auto'`.
 
     periodic : iterable, optional
@@ -387,7 +387,7 @@ def NestedSampler(loglikelihood,
             sample = 'rwalk'
         else:
             if gradient is None:
-                sample = 'slice'
+                sample = 'rslice'
             else:
                 sample = 'hslice'
 
@@ -699,8 +699,8 @@ def DynamicNestedSampler(loglikelihood,
         When `ndim < 10`, this defaults to `'unif'`.
         When `10 <= ndim <= 20`, this defaults to `'rwalk'`.
         When `ndim > 20`, this defaults to `'hslice'` if a `gradient` is
-        provided and `'slice'` otherwise. `'rstagger'` and `'rslice'`
-        are provided as alternatives for `'rwalk'` and `'slice'`, respectively.
+        provided and `'rslice'` otherwise. `'rstagger'` and `'slice'`
+        are provided as alternatives for `'rwalk'` and `'rslice'`, respectively.
         Default is `'auto'`.
 
     periodic : iterable, optional
@@ -882,7 +882,7 @@ def DynamicNestedSampler(loglikelihood,
             sample = 'rwalk'
         else:
             if gradient is None:
-                sample = 'slice'
+                sample = 'rslice'
             else:
                 sample = 'hslice'
 

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -129,7 +129,6 @@ def NestedSampler(loglikelihood,
                   compute_jac=False,
                   enlarge=None,
                   bootstrap=0,
-                  vol_dec=0.5,
                   walks=25,
                   facc=0.5,
                   slices=5,
@@ -318,11 +317,6 @@ def NestedSampler(loglikelihood,
         out during each iteration to enlarge the resulting volumes. Can
         lead to unstable bounding ellipsoids. Default is `0` (no bootstrap).
 
-    vol_dec : float, optional
-        For the `'multi'` bounding option, the required fractional reduction
-        in volume after splitting an ellipsoid in order to to accept the split.
-        Default is `0.5`.
-
     walks : int, optional
         For the `'rwalk'` sampling option, the minimum number of steps
         (minimum 2) before proposing a new live point. Default is `25`.
@@ -479,8 +473,6 @@ def NestedSampler(loglikelihood,
         kwargs['enlarge'] = enlarge
     if bootstrap is not None:
         kwargs['bootstrap'] = bootstrap
-    if vol_dec is not None:
-        kwargs['vol_dec'] = vol_dec
 
     # Sampling.
     if walks is not None:
@@ -638,7 +630,6 @@ def DynamicNestedSampler(loglikelihood,
                          compute_jac=False,
                          enlarge=None,
                          bootstrap=0,
-                         vol_dec=0.5,
                          walks=25,
                          facc=0.5,
                          slices=5,
@@ -813,11 +804,6 @@ def DynamicNestedSampler(loglikelihood,
         out during each iteration to enlarge the resulting volumes. Can lead
         to unstable bounding ellipsoids. Default is `0` (no bootstrap).
 
-    vol_dec : float, optional
-        For the `'multi'` bounding option, the required fractional reduction
-        in volume after splitting an ellipsoid in order to to accept the split.
-        Default is `0.5`.
-
     walks : int, optional
         For the `'rwalk'` sampling option, the minimum number of steps
         (minimum 2) before proposing a new live point. Default is `25`.
@@ -964,8 +950,6 @@ def DynamicNestedSampler(loglikelihood,
         kwargs['enlarge'] = enlarge
     if bootstrap is not None:
         kwargs['bootstrap'] = bootstrap
-    if vol_dec is not None:
-        kwargs['vol_dec'] = vol_dec
 
     # Sampling.
     if walks is not None:

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -130,7 +130,6 @@ def NestedSampler(loglikelihood,
                   enlarge=None,
                   bootstrap=0,
                   vol_dec=0.5,
-                  vol_check=2.0,
                   walks=25,
                   facc=0.5,
                   slices=5,
@@ -324,12 +323,6 @@ def NestedSampler(loglikelihood,
         in volume after splitting an ellipsoid in order to to accept the split.
         Default is `0.5`.
 
-    vol_check : float, optional
-        For the `'multi'` bounding option, the factor used when checking if
-        the volume of the original bounding ellipsoid is large enough to
-        warrant `> 2` splits via `ell.vol > vol_check * nlive * pointvol`.
-        Default is `2.0`.
-
     walks : int, optional
         For the `'rwalk'` sampling option, the minimum number of steps
         (minimum 2) before proposing a new live point. Default is `25`.
@@ -488,8 +481,6 @@ def NestedSampler(loglikelihood,
         kwargs['bootstrap'] = bootstrap
     if vol_dec is not None:
         kwargs['vol_dec'] = vol_dec
-    if vol_check is not None:
-        kwargs['vol_check'] = vol_check
 
     # Sampling.
     if walks is not None:
@@ -648,7 +639,6 @@ def DynamicNestedSampler(loglikelihood,
                          enlarge=None,
                          bootstrap=0,
                          vol_dec=0.5,
-                         vol_check=2.0,
                          walks=25,
                          facc=0.5,
                          slices=5,
@@ -828,12 +818,6 @@ def DynamicNestedSampler(loglikelihood,
         in volume after splitting an ellipsoid in order to to accept the split.
         Default is `0.5`.
 
-    vol_check : float, optional
-        For the `'multi'` bounding option, the factor used when checking if
-        the volume of the original bounding ellipsoid is large enough to
-        warrant `> 2` splits via `ell.vol > vol_check * nlive * pointvol`.
-        Default is `2.0`.
-
     walks : int, optional
         For the `'rwalk'` sampling option, the minimum number of steps
         (minimum 2) before proposing a new live point. Default is `25`.
@@ -982,8 +966,6 @@ def DynamicNestedSampler(loglikelihood,
         kwargs['bootstrap'] = bootstrap
     if vol_dec is not None:
         kwargs['vol_dec'] = vol_dec
-    if vol_check is not None:
-        kwargs['vol_check'] = vol_check
 
     # Sampling.
     if walks is not None:
@@ -1069,7 +1051,7 @@ class _function_wrapper(object):
     def __call__(self, x):
         try:
             return self.func(x, *self.args, **self.kwargs)
-        except:
+        except:  # noqa
             import traceback
             print("Exception while calling {0} function:".format(self.name))
             print("  params:", x)

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -650,7 +650,6 @@ class MultiEllipsoidSampler(Sampler):
             self.enlarge = kwargs.get('enlarge', 1.0)
         else:
             self.enlarge = kwargs.get('enlarge', 1.25)
-        self.vol_dec = kwargs.get('vol_dec', 0.5)
         self.cite = self.kwargs.get('cite')
 
         self.mell = MultiEllipsoid(ctrs=[np.zeros(self.ncdim)],
@@ -685,7 +684,6 @@ class MultiEllipsoidSampler(Sampler):
 
         # Update the bounding ellipsoids.
         self.mell.update(self.live_u[:, :self.ncdim],
-                         vol_dec=self.vol_dec,
                          rstate=self.rstate,
                          bootstrap=self.bootstrap,
                          pool=pool)

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -651,7 +651,6 @@ class MultiEllipsoidSampler(Sampler):
         else:
             self.enlarge = kwargs.get('enlarge', 1.25)
         self.vol_dec = kwargs.get('vol_dec', 0.5)
-        self.vol_check = kwargs.get('vol_check', 2.0)
         self.cite = self.kwargs.get('cite')
 
         self.mell = MultiEllipsoid(ctrs=[np.zeros(self.ncdim)],
@@ -687,7 +686,6 @@ class MultiEllipsoidSampler(Sampler):
         # Update the bounding ellipsoids.
         self.mell.update(self.live_u[:, :self.ncdim],
                          vol_dec=self.vol_dec,
-                         vol_check=self.vol_check,
                          rstate=self.rstate,
                          bootstrap=self.bootstrap,
                          pool=pool)

--- a/tests/test_highdim.py
+++ b/tests/test_highdim.py
@@ -1,0 +1,94 @@
+import numpy as np
+from scipy import linalg
+import scipy.stats
+import dynesty
+import multiprocessing as mp
+"""
+Run a series of basic tests to check whether anything huge is broken.
+
+"""
+
+nlive = 5000
+printing = False
+
+
+def get_covar(rstate, ndim):
+    eigval = 10**np.linspace(-3, 0, ndim)
+    M = scipy.stats.ortho_group.rvs(dim=ndim, random_state=rstate)
+    ret = M @ np.diag(eigval**2) @ M.T
+    return ret
+
+
+class Config:
+    def __init__(self, rstate, ndim_gau):
+        self.ndim_gau = ndim_gau
+        self.mean_gau = np.linspace(-1, 1, ndim_gau)
+        cov_gau = get_covar(rstate, ndim_gau)
+        self.cov_gau = cov_gau
+        self.cov_inv_gau = linalg.pinvh(cov_gau)  # precision matrix
+        logdet = np.linalg.slogdet(cov_gau)[1]
+        self.lnorm_gau = -0.5 * (np.log(2 * np.pi) * ndim_gau + logdet)
+        self.prior_win = 1000  # +/- 10 on both sides
+        self.logz_truth_gau = ndim_gau * (-np.log(2 * self.prior_win))
+        assert (np.isfinite(self.lnorm_gau))
+        assert (np.isfinite(self.logz_truth_gau))
+
+
+class si:
+    config = None
+
+
+# 3-D correlated multivariate normal log-likelihood
+class LogL:
+    def __init__(self, config):
+        self.config = config
+
+    def __call__(self, x):
+        """Multivariate normal log-likelihood."""
+        co = self.config
+        x1 = x - co.mean_gau
+        return -0.5 * x1 @ co.cov_inv_gau @ x1 + co.lnorm_gau
+
+
+# prior transform
+
+
+class Prior:
+    def __init__(self, config):
+        self.config = config
+
+    def __call__(self, x):
+        """Flat prior between -10. and 10."""
+        return self.config.prior_win * (2. * x - 1.)
+
+
+def do_gaussian(co, sample=None, bound=None, rstate=None):
+    curlogl = LogL(co)
+    curprior = Prior(co)
+    sampler = dynesty.DynamicNestedSampler(curlogl,
+                                           curprior,
+                                           co.ndim_gau,
+                                           nlive=nlive,
+                                           bound=bound,
+                                           sample=sample,
+                                           rstate=rstate,
+                                           vol_dec=.25)
+    sampler.run_nested(print_progress=printing)
+    res = sampler.results
+    return res.logz[-1], res.logzerr[-1]
+
+
+def do_gaussians(sample='rslice', bound='single'):
+    pool = mp.Pool(36)
+    res = []
+    for ndim in range(2, 33):
+        rstate = np.random.RandomState(seed=ndim)
+        co = Config(rstate, ndim)
+        res.append(
+            (ndim, co,
+             pool.apply_async(do_gaussian, (co, ),
+                              dict(sample=sample, bound=bound,
+                                   rstate=rstate))))
+    for ndim, co, curres in res:
+        curres = curres.get()
+        print('RESULTS', ndim, curres, co.logz_truth_gau)


### PR DESCRIPTION
following #285
make the conditions stricter on hierarchical splits if the first split didn't work
also get rid of no-op vol_check option.

This partially recovers the losses of #284 (blue curve) as the deviations start to now happen at ndim=17
![image](https://user-images.githubusercontent.com/109513/121966965-6ed96a80-cd67-11eb-884b-56664f11253c.png)

I'm not sure we'll be able to fully get it back, as the previous code used pointvol for this. In my mind there were cases where pointvol estimates were good and it was preventing excessive splitting but in some cases it was preventing splitting because of incorrect pointvols.


I also change the sampler to rslice in high dims.  