### PR TITLE
Overflow fix

### DIFF
--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -21,9 +21,6 @@ useful helper functions. Bounding objects include:
 
 """
 
-from __future__ import (print_function, division)
-from six.moves import range
-
 import warnings
 import math
 import numpy as np

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -989,7 +989,6 @@ class DynamicSampler(object):
 
         # Check whether the lower bound encompasses all previous saved samples.
         psel = np.all(logl_min <= saved_logl)
-        vol = 1. - 1. / nblive  # starting ln(prior volume)
         if psel:
             # If the lower bound encompasses all saved samples, we want
             # to propose a new set of points from the unit cube.
@@ -1757,5 +1756,5 @@ class DynamicSampler(object):
             return ncall, niter, logl_bounds, results
         else:
             raise RuntimeError(
-                'add_batch called with no leftover function calls or iterations'
-            )
+                'add_batch called with no leftover function calls'
+                'or iterations')

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -11,19 +11,13 @@ by the user.
 
 """
 
-from __future__ import (print_function, division)
-from six.moves import range
-
 import sys
 import warnings
 from functools import partial
 import math
 import numpy as np
 import copy
-try:
-    from scipy.special import logsumexp
-except ImportError:
-    from scipy.misc import logsumexp
+from scipy.special import logsumexp
 
 try:
     import tqdm

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -1332,10 +1332,11 @@ class DynamicSampler(object):
             logdvol, dlv = logdvols[i], dlvs[i]
             logwt = np.logaddexp(loglstar_new, loglstar) + logdvol
             logz_new = np.logaddexp(logz, logwt)
-            lzterm = (math.exp(loglstar - logz_new) * loglstar +
-                      math.exp(loglstar_new - logz_new) * loglstar_new)
-            h_new = (math.exp(logdvol) * lzterm + math.exp(logz - logz_new) *
-                     (h + logz) - logz_new)
+            lzterm = (
+                math.exp(loglstar - logz_new + logdvol) * loglstar +
+                math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
+            h_new = (lzterm + math.exp(logz - logz_new) * (h + logz) -
+                     logz_new)
             dh = h_new - h
             h = h_new
             logz = logz_new

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -193,7 +193,8 @@ def NestedSampler(loglikelihood,
         When `10 <= ndim <= 20`, this defaults to `'rwalk'`.
         When `ndim > 20`, this defaults to `'hslice'` if a `gradient` is
         provided and `'rslice'` otherwise. `'rstagger'` and `'slice'`
-        are provided as alternatives for `'rwalk'` and `'rslice'`, respectively.
+        are provided as alternatives for `'rwalk'` and `'rslice'`,
+        respectively.
         Default is `'auto'`.
 
     periodic : iterable, optional
@@ -689,7 +690,8 @@ def DynamicNestedSampler(loglikelihood,
         When `10 <= ndim <= 20`, this defaults to `'rwalk'`.
         When `ndim > 20`, this defaults to `'hslice'` if a `gradient` is
         provided and `'rslice'` otherwise. `'rstagger'` and `'slice'`
-        are provided as alternatives for `'rwalk'` and `'rslice'`, respectively.
+        are provided as alternatives for `'rwalk'` and `'rslice'`,
+        respectively.
         Default is `'auto'`.
 
     periodic : iterable, optional

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -403,10 +403,6 @@ def NestedSampler(loglikelihood,
     # Dimensional warning check.
     if nlive <= 2 * ndim:
         warnings.warn("Beware! Having `nlive <= 2 * ndim` is extremely risky!")
-    elif nlive < ndim * (ndim + 1) // 2 and bound in ['single', 'multi']:
-        warnings.warn("A note of caution: "
-                      "having `nlive < ndim * (ndim + 1) // 2` may result in "
-                      "unconstrained bounding distributions.")
 
     # Gather boundary conditions.
     if periodic is not None and reflective is not None:

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -7,8 +7,6 @@ provides access to the two main sampler "super-classes" via
 
 """
 
-from __future__ import (print_function, division)
-
 import sys
 import warnings
 import math

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -23,8 +23,6 @@ Includes:
 
 """
 
-from __future__ import (print_function, division)
-
 import math
 import numpy as np
 import copy

--- a/py/dynesty/plotting.py
+++ b/py/dynesty/plotting.py
@@ -6,11 +6,8 @@ sampling :class:`~dynesty.results.Results`.
 
 """
 
-from __future__ import (print_function, division)
-from six.moves import range
-
 import logging
-import types
+import warnings
 import numpy as np
 import matplotlib.pyplot as pl
 from matplotlib.ticker import MaxNLocator, NullLocator
@@ -19,7 +16,6 @@ from matplotlib.ticker import ScalarFormatter
 from scipy import spatial
 from scipy.ndimage import gaussian_filter as norm_kde
 from scipy.stats import gaussian_kde
-import warnings
 from .utils import resample_equal, unitcheck
 from .utils import quantile as _quantile
 

--- a/py/dynesty/results.py
+++ b/py/dynesty/results.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 """
 Utilities for handling results.
 
 """
-
-from __future__ import (print_function, division)
 
 import sys
 import numpy as np
@@ -15,9 +12,16 @@ import shutil
 __all__ = ["Results", "print_fn"]
 
 
-def print_fn(results, niter, ncall, add_live_it=None,
-             dlogz=None, stop_val=None, nbatch=None,
-             logl_min=-np.inf, logl_max=np.inf, pbar=None):
+def print_fn(results,
+             niter,
+             ncall,
+             add_live_it=None,
+             dlogz=None,
+             stop_val=None,
+             nbatch=None,
+             logl_min=-np.inf,
+             logl_max=np.inf,
+             pbar=None):
     """
     The default function used to print out results in real time.
 
@@ -74,22 +78,40 @@ def print_fn(results, niter, ncall, add_live_it=None,
 
     """
     if pbar is None:
-        print_fn_fallback(results, niter, ncall, add_live_it=add_live_it,
-                          dlogz=dlogz, stop_val=stop_val, nbatch=nbatch,
-                          logl_min=logl_min, logl_max=logl_max)
+        print_fn_fallback(results,
+                          niter,
+                          ncall,
+                          add_live_it=add_live_it,
+                          dlogz=dlogz,
+                          stop_val=stop_val,
+                          nbatch=nbatch,
+                          logl_min=logl_min,
+                          logl_max=logl_max)
     else:
-        print_fn_tqdm(pbar, results, niter, ncall, add_live_it=add_live_it,
-                      dlogz=dlogz, stop_val=stop_val, nbatch=nbatch,
-                      logl_min=logl_min, logl_max=logl_max)
+        print_fn_tqdm(pbar,
+                      results,
+                      niter,
+                      ncall,
+                      add_live_it=add_live_it,
+                      dlogz=dlogz,
+                      stop_val=stop_val,
+                      nbatch=nbatch,
+                      logl_min=logl_min,
+                      logl_max=logl_max)
 
 
-def get_print_fn_args(results, niter, ncall, add_live_it=None,
-                      dlogz=None, stop_val=None, nbatch=None,
-                      logl_min=-np.inf, logl_max=np.inf):
+def get_print_fn_args(results,
+                      niter,
+                      ncall,
+                      add_live_it=None,
+                      dlogz=None,
+                      stop_val=None,
+                      nbatch=None,
+                      logl_min=-np.inf,
+                      logl_max=np.inf):
     # Extract results at the current iteration.
-    (worst, ustar, vstar, loglstar, logvol, logwt,
-     logz, logzvar, h, nc, worst_it, boundidx, bounditer,
-     eff, delta_logz) = results
+    (worst, ustar, vstar, loglstar, logvol, logwt, logz, logzvar, h, nc,
+     worst_it, boundidx, bounditer, eff, delta_logz) = results
 
     # Adjusting outputs for printing.
     if delta_logz > 1e6:
@@ -116,12 +138,10 @@ def get_print_fn_args(results, niter, ncall, add_live_it=None,
     long_str.append("ncall: {:d}".format(ncall))
     long_str.append("eff(%): {:6.3f}".format(eff))
     short_str.append(long_str[-1])
-    long_str.append("loglstar: {:6.3f} < {:6.3f} < {:6.3f}".format(logl_min,
-                                                                   loglstar,
-                                                                   logl_max))
-    short_str.append("logl*: {:6.1f}<{:6.1f}<{:6.1f}".format(logl_min,
-                                                             loglstar,
-                                                             logl_max))
+    long_str.append("loglstar: {:6.3f} < {:6.3f} < {:6.3f}".format(
+        logl_min, loglstar, logl_max))
+    short_str.append("logl*: {:6.1f}<{:6.1f}<{:6.1f}".format(
+        logl_min, loglstar, logl_max))
     long_str.append("logz: {:6.3f} +/- {:6.3f}".format(logz, logzerr))
     short_str.append("logz: {:6.1f}+/-{:.1f}".format(logz, logzerr))
     mid_str = list(short_str)
@@ -135,23 +155,50 @@ def get_print_fn_args(results, niter, ncall, add_live_it=None,
     return niter, short_str, mid_str, long_str
 
 
-def print_fn_tqdm(pbar, results, niter, ncall, add_live_it=None,
-                  dlogz=None, stop_val=None, nbatch=None,
-                  logl_min=-np.inf, logl_max=np.inf):
+def print_fn_tqdm(pbar,
+                  results,
+                  niter,
+                  ncall,
+                  add_live_it=None,
+                  dlogz=None,
+                  stop_val=None,
+                  nbatch=None,
+                  logl_min=-np.inf,
+                  logl_max=np.inf):
     niter, short_str, mid_str, long_str = get_print_fn_args(
-        results, niter, ncall, add_live_it=add_live_it, dlogz=dlogz,
-        stop_val=stop_val, nbatch=nbatch, logl_min=logl_min, logl_max=logl_max)
+        results,
+        niter,
+        ncall,
+        add_live_it=add_live_it,
+        dlogz=dlogz,
+        stop_val=stop_val,
+        nbatch=nbatch,
+        logl_min=logl_min,
+        logl_max=logl_max)
 
     pbar.set_postfix_str(" | ".join(long_str), refresh=False)
     pbar.update(niter - pbar.n)
 
 
-def print_fn_fallback(results, niter, ncall, add_live_it=None,
-                      dlogz=None, stop_val=None, nbatch=None,
-                      logl_min=-np.inf, logl_max=np.inf):
+def print_fn_fallback(results,
+                      niter,
+                      ncall,
+                      add_live_it=None,
+                      dlogz=None,
+                      stop_val=None,
+                      nbatch=None,
+                      logl_min=-np.inf,
+                      logl_max=np.inf):
     niter, short_str, mid_str, long_str = get_print_fn_args(
-        results, niter, ncall, add_live_it=add_live_it, dlogz=dlogz,
-        stop_val=stop_val, nbatch=nbatch, logl_min=logl_min, logl_max=logl_max)
+        results,
+        niter,
+        ncall,
+        add_live_it=add_live_it,
+        dlogz=dlogz,
+        stop_val=stop_val,
+        nbatch=nbatch,
+        logl_min=logl_min,
+        logl_max=logl_max)
 
     long_str = ["iter: {:d}".format(niter)] + long_str
 
@@ -164,18 +211,18 @@ def print_fn_fallback(results, niter, ncall, add_live_it=None,
     else:
         columns = 200
     if columns > len(long_str):
-        sys.stderr.write("\r" + long_str + ' '*(columns-len(long_str)-2))
+        sys.stderr.write("\r" + long_str + ' ' * (columns - len(long_str) - 2))
     elif columns > len(mid_str):
-        sys.stderr.write("\r" + mid_str + ' '*(columns-len(mid_str)-2))
+        sys.stderr.write("\r" + mid_str + ' ' * (columns - len(mid_str) - 2))
     else:
-        sys.stderr.write("\r" + short_str + ' '*(columns-len(short_str)-2))
+        sys.stderr.write("\r" + short_str + ' ' *
+                         (columns - len(short_str) - 2))
     sys.stderr.flush()
 
 
 class Results(dict):
     """Contains the full output of a run along with a set of helper
     functions for summarizing the output."""
-
     def __getattr__(self, name):
         try:
             return self[name]
@@ -188,8 +235,8 @@ class Results(dict):
     def __repr__(self):
         if self.keys():
             m = max(list(map(len, list(self.keys())))) + 1
-            return '\n'.join([k.rjust(m) + ': ' + repr(v)
-                              for k, v in self.items()])
+            return '\n'.join(
+                [k.rjust(m) + ': ' + repr(v) for k, v in self.items()])
         else:
             return self.__class__.__name__ + "()"
 
@@ -201,8 +248,9 @@ class Results(dict):
                "niter: {:d}\n"
                "ncall: {:d}\n"
                "eff(%): {:6.3f}\n"
-               "logz: {:6.3f} +/- {:6.3f}"
-               .format(self.nlive, self.niter, sum(self.ncall),
-                       self.eff, self.logz[-1], self.logzerr[-1]))
+               "logz: {:6.3f} +/- {:6.3f}".format(self.nlive, self.niter,
+                                                  sum(self.ncall), self.eff,
+                                                  self.logz[-1],
+                                                  self.logzerr[-1]))
 
-        print('Summary\n=======\n'+res)
+        print('Summary\n=======\n' + res)

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -6,19 +6,13 @@ samplers inherit this class either explicitly or implicitly.
 
 """
 
-from __future__ import (print_function, division)
-from six.moves import range
-
 import sys
 import warnings
 from functools import partial
 import math
 import copy
 import numpy as np
-try:
-    from scipy.special import logsumexp
-except ImportError:
-    from scipy.misc import logsumexp
+from scipy.special import logsumexp
 
 try:
     import tqdm

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -503,10 +503,11 @@ class Sampler(object):
             # Compute relative contribution to results.
             logwt = np.logaddexp(loglstar_new, loglstar) + logdvol  # weight
             logz_new = np.logaddexp(logz, logwt)  # ln(evidence)
-            lzterm = (math.exp(loglstar - logz_new) * loglstar +
-                      math.exp(loglstar_new - logz_new) * loglstar_new)
-            h_new = (math.exp(logdvol) * lzterm + math.exp(logz - logz_new) *
-                     (h + logz) - logz_new)  # information
+            lzterm = (
+                math.exp(loglstar - logz_new + logdvol) * loglstar +
+                math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
+            h_new = (lzterm + math.exp(logz - logz_new) * (h + logz) - logz_new
+                     )  # information
             dh = h_new - h
             h = h_new
             logz = logz_new
@@ -803,10 +804,11 @@ class Sampler(object):
 
             # Update evidence `logz` and information `h`.
             logz_new = np.logaddexp(logz, logwt)
-            lzterm = (math.exp(loglstar - logz_new) * loglstar +
-                      math.exp(loglstar_new - logz_new) * loglstar_new)
-            h_new = (math.exp(logdvol) * lzterm + math.exp(logz - logz_new) *
-                     (h + logz) - logz_new)
+            lzterm = (
+                math.exp(loglstar - logz_new + logdvol) * loglstar +
+                math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
+            h_new = (lzterm + math.exp(logz - logz_new) * (h + logz) -
+                     logz_new)
             dh = h_new - h
             h = h_new
             logz = logz_new

--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -8,9 +8,6 @@ Functions for proposing new live points used by
 
 """
 
-from __future__ import (print_function, division)
-from six.moves import range
-
 import warnings
 import math
 import numpy as np

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -709,8 +709,7 @@ def resample_run(res, rstate=None, return_idx=False):
         logz_new = np.logaddexp(logz, logwt)
         lzterm = (math.exp(loglstar - logz_new + logdvol) * loglstar +
                   math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
-        h_new = (lzterm + math.exp(logz - logz_new) *
-                 (h + logz) - logz_new)
+        h_new = (lzterm + math.exp(logz - logz_new) * (h + logz) - logz_new)
         dh = h_new - h
         h = h_new
         logz = logz_new
@@ -847,10 +846,9 @@ def reweight_run(res, logp_new, logp_old=None):
         logdvol, dlv = logdvols[i], dlvs[i]
         logwt = np.logaddexp(loglstar_new, loglstar) + logdvol + logrwt[i]
         logz_new = np.logaddexp(logz, logwt)
-        lzterm = (math.exp(loglstar - logz_new + logdvol ) * loglstar +
-                      math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
-        h_new = lzterm + math.exp(logz - logz_new) *
-                 (h + logz) - logz_new)
+        lzterm = (math.exp(loglstar - logz_new + logdvol) * loglstar +
+                  math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
+        h_new = (lzterm + math.exp(logz - logz_new) * (h + logz) - logz_new)
         dh = h_new - h
         h = h_new
         logz = logz_new
@@ -956,10 +954,11 @@ def unravel_run(res, save_proposals=True, print_progress=True):
             logdvol, dlv = logdvols[i], dlvs[i]
             logwt = np.logaddexp(loglstar_new, loglstar) + logdvol
             logz_new = np.logaddexp(logz, logwt)
-            lzterm = (math.exp(loglstar - logz_new + logdvol) * loglstar +
-                      math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
-            h_new = (lzterm + math.exp(logz - logz_new) *
-                     (h + logz) - logz_new)
+            lzterm = (
+                math.exp(loglstar - logz_new + logdvol) * loglstar +
+                math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
+            h_new = (lzterm + math.exp(logz - logz_new) * (h + logz) -
+                     logz_new)
             dh = h_new - h
             h = h_new
             logz = logz_new
@@ -1533,10 +1532,11 @@ def _merge_two(res1, res2, compute_aux=False):
             logdvol, dlv = logdvols[i], dlvs[i]
             logwt = np.logaddexp(loglstar_new, loglstar) + logdvol
             logz_new = np.logaddexp(logz, logwt)
-            lzterm = (math.exp(loglstar - logz_new + logdvol) * loglstar +
-                      math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
-            h_new = (lzterm + math.exp(logz - logz_new) *
-                     (h + logz) - logz_new)
+            lzterm = (
+                math.exp(loglstar - logz_new + logdvol) * loglstar +
+                math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
+            h_new = (lzterm + math.exp(logz - logz_new) * (h + logz) -
+                     logz_new)
             dh = h_new - h
             h = h_new
             logz = logz_new

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -35,7 +35,7 @@ class LogLikelihood:
                  save=False,
                  history_filename=None):
         """ Initialize the object.
-        
+
         Parameters:
         loglikelihood: function
         ndim: int
@@ -60,7 +60,7 @@ class LogLikelihood:
             self.history_init()
 
     def map(self, pars):
-        """ Evaluate the likelihood f-n on the list of vectors 
+        """ Evaluate the likelihood f-n on the list of vectors
         The pool is used if it was provided when the object was created
         """
         if self.pool is None:
@@ -258,7 +258,6 @@ def resample_equal(samples, weights, rstate=None):
     -----
     Implements the systematic resampling method described in `Hol, Schon, and
     Gustafsson (2006) <doi:10.1109/NSSPW.2006.4378824>`_.
- 
    """
 
     if rstate is None:
@@ -377,8 +376,8 @@ def _find_decrease(samples_n):
     """
     Find all instances where the number of live points is either constant
     or increasing.
-    Returne the mask, 
-    the values of nlive when nlives starts to decrease 
+    Return the mask,
+    the values of nlive when nlives starts to decrease
     The ranges of decreasing nlives
     v=[3,2,1,13,13,12,23,22];
     > print(dynesty.utils._find_decrease(v))

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -525,17 +525,13 @@ def jitter_run(res, rstate=None, approx=False):
 
     # H is defined as
     # H = 1/z int( L * ln(L) dX,X=0..1) - ln(z)
-    # Therefore delta(z(H+ln(z))) = int(L * ln(L), X=X_i..X_i+1)
-    # where delta is a change from iteration to iteration
-    # Therefore z_{i+1}*(H_{i+1}+ln(Z_{i+1})) - z_{i}*(H_{i}+ln(Z_{i}))
-    # equals to L_i ln(L_i) + L_{i+1} * ln(L_{i+1}) * (X_{i+1} - X_i)/2
-    # by doing trapezoid integration
-    zhlnz = np.cumsum(
+    # incomplete H can be defined as
+    # H = int( L/Z * ln(L) dX,X=0..x) - z_x/Z * ln(Z)
+    h_part1 = np.cumsum(
         (np.exp(loglstar_pad[1:] - logzmax + logdvol2) * loglstar_pad[1:] +
          np.exp(loglstar_pad[:-1] - logzmax + logdvol2) * loglstar_pad[:-1]))
     # here we divide the likelihood by zmax to avoid to overflow
-    # print(zhlnz, logzmax, saved_logz)
-    saved_h = zhlnz - logzmax * np.exp(saved_logz - logzmax)
+    saved_h = h_part1 - logzmax * np.exp(saved_logz - logzmax)
     # changes in h in each step
     dh = np.diff(saved_h, prepend=0)
 

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -990,14 +990,14 @@ def unravel_run(res, save_proposals=True, print_progress=True):
                 r.append(('prop_iter', res.prop_iter[strand]))
                 r.append(('samples_prop', res.samples_prop[strand]))
                 r.append(('scale', res.scale[strand]))
-            except:
+            except AttributeError:
                 pass
 
         # Add on batch information (if available).
         try:
             r.append(('samples_batch', res.samples_batch[strand]))
             r.append(('batch_bounds', res.batch_bounds))
-        except:
+        except AttributeError:
             pass
 
         # Append to list of strands.
@@ -1312,7 +1312,7 @@ def _merge_two(res1, res2, compute_aux=False):
     # Number of live points throughout the run.
     try:
         base_n = res1.samples_n
-    except:
+    except AttributeError:
         niter, nlive = res1.niter, res1.nlive
         if nbase == niter:
             base_n = np.ones(niter, dtype=int) * nlive
@@ -1331,14 +1331,14 @@ def _merge_two(res1, res2, compute_aux=False):
         base_piter = res1.prop_iter
         base_scale = res1.scale
         base_proposals = True
-    except:
+    except AttributeError:
         base_proposals = False
 
     # Batch information (if available).
     try:
         base_batch = res1.samples_batch
         base_bounds = res1.batch_bounds
-    except:
+    except AttributeError:
         base_batch = np.zeros(nbase, dtype=int)
         base_bounds = np.array([(-np.inf, np.inf)])
 
@@ -1354,7 +1354,7 @@ def _merge_two(res1, res2, compute_aux=False):
     # Number of live points throughout the run.
     try:
         new_n = res2.samples_n
-    except:
+    except AttributeError:
         niter, nlive = res2.niter, res2.nlive
         if nnew == niter:
             new_n = np.ones(niter, dtype=int) * nlive
@@ -1373,14 +1373,14 @@ def _merge_two(res1, res2, compute_aux=False):
         new_piter = res2.prop_iter
         new_scale = res2.scale
         new_proposals = True
-    except:
+    except AttributeError:
         new_proposals = False
 
     # Batch information (if available).
     try:
         new_batch = res2.samples_batch
         new_bounds = res2.batch_bounds
-    except:
+    except AttributeError:
         new_batch = np.zeros(nnew, dtype=int)
         new_bounds = np.array([(-np.inf, np.inf)])
 

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -711,9 +711,9 @@ def resample_run(res, rstate=None, return_idx=False):
         logdvol, dlv = logdvols[i], dlvs[i]
         logwt = np.logaddexp(loglstar_new, loglstar) + logdvol
         logz_new = np.logaddexp(logz, logwt)
-        lzterm = (math.exp(loglstar - logz_new) * loglstar +
-                  math.exp(loglstar_new - logz_new) * loglstar_new)
-        h_new = (math.exp(logdvol) * lzterm + math.exp(logz - logz_new) *
+        lzterm = (math.exp(loglstar - logz_new + logdvol) * loglstar +
+                  math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
+        h_new = (lzterm + math.exp(logz - logz_new) *
                  (h + logz) - logz_new)
         dh = h_new - h
         h = h_new
@@ -851,12 +851,9 @@ def reweight_run(res, logp_new, logp_old=None):
         logdvol, dlv = logdvols[i], dlvs[i]
         logwt = np.logaddexp(loglstar_new, loglstar) + logdvol + logrwt[i]
         logz_new = np.logaddexp(logz, logwt)
-        try:
-            lzterm = (math.exp(loglstar - logz_new) * loglstar +
-                      math.exp(loglstar_new - logz_new) * loglstar_new)
-        except:
-            lzterm = 0.
-        h_new = (math.exp(logdvol) * lzterm + math.exp(logz - logz_new) *
+        lzterm = (math.exp(loglstar - logz_new + logdvol ) * loglstar +
+                      math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
+        h_new = lzterm + math.exp(logz - logz_new) *
                  (h + logz) - logz_new)
         dh = h_new - h
         h = h_new
@@ -963,9 +960,9 @@ def unravel_run(res, save_proposals=True, print_progress=True):
             logdvol, dlv = logdvols[i], dlvs[i]
             logwt = np.logaddexp(loglstar_new, loglstar) + logdvol
             logz_new = np.logaddexp(logz, logwt)
-            lzterm = (math.exp(loglstar - logz_new) * loglstar +
-                      math.exp(loglstar_new - logz_new) * loglstar_new)
-            h_new = (math.exp(logdvol) * lzterm + math.exp(logz - logz_new) *
+            lzterm = (math.exp(loglstar - logz_new + logdvol) * loglstar +
+                      math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
+            h_new = (lzterm + math.exp(logz - logz_new) *
                      (h + logz) - logz_new)
             dh = h_new - h
             h = h_new
@@ -1540,9 +1537,9 @@ def _merge_two(res1, res2, compute_aux=False):
             logdvol, dlv = logdvols[i], dlvs[i]
             logwt = np.logaddexp(loglstar_new, loglstar) + logdvol
             logz_new = np.logaddexp(logz, logwt)
-            lzterm = (math.exp(loglstar - logz_new) * loglstar +
-                      math.exp(loglstar_new - logz_new) * loglstar_new)
-            h_new = (math.exp(logdvol) * lzterm + math.exp(logz - logz_new) *
+            lzterm = (math.exp(loglstar - logz_new + logdvol) * loglstar +
+                      math.exp(loglstar_new - logz_new + logdvol) * loglstar_new)
+            h_new = (lzterm + math.exp(logz - logz_new) *
                      (h + logz) - logz_new)
             dh = h_new - h
             h = h_new

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,5 +1,6 @@
 import numpy as np
 import dynesty
+import dynesty.utils as dyutil
 """
 Run a series of basic tests changing various things like
 maxcall options and potentially other things
@@ -57,3 +58,24 @@ def test_inf():
                                            ndim,
                                            nlive=nlive)
     sampler.run_nested(dlogz_init=1)
+
+
+def test_unravel():
+    # hard test of dynamic sampler with high dlogz_init and small number
+    # of live points
+    ndim = 2
+    sampler = dynesty.NestedSampler(loglike,
+                                    prior_transform,
+                                    ndim,
+                                    nlive=nlive)
+    sampler.run_nested()
+    dyutil.unravel_run(sampler.results)
+
+    sampler = dynesty.DynamicNestedSampler(loglike,
+                                           prior_transform,
+                                           ndim,
+                                           nlive=nlive)
+    sampler.run_nested(dlogz_init=1, maxcall=1000)
+    dyutil.unravel_run(sampler.results)
+    logps = sampler.results.logl
+    dyutil.reweight_run(sampler.results, logps / 4.)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -79,3 +79,27 @@ def test_unravel():
     dyutil.unravel_run(sampler.results)
     logps = sampler.results.logl
     dyutil.reweight_run(sampler.results, logps / 4.)
+
+
+def test_livepoints():
+    # hard test of dynamic sampler with high dlogz_init and small number
+    # of live points
+    ndim = 2
+    live_u = np.random.uniform(size=(ndim, 2))
+    live_v = np.array([prior_transform(_) for _ in live_u])
+    live_logl = np.array([loglike(_) for _ in live_v])
+    live_points = [live_u, live_v, live_logl]
+    sampler = dynesty.NestedSampler(loglike,
+                                    prior_transform,
+                                    ndim,
+                                    nlive=nlive,
+                                    live_points=live_points)
+    sampler.run_nested()
+    dyutil.unravel_run(sampler.results)
+
+    sampler = dynesty.DynamicNestedSampler(loglike,
+                                           prior_transform,
+                                           ndim,
+                                           nlive=nlive,
+                                           live_points=live_points)
+    sampler.run_nested(dlogz_init=1, maxcall=1000)


### PR DESCRIPTION
Fix the overflow problem  that happens when trying to run on 128d gaussian 

```
In [1]: import test_highdim as T
In [7]: co= T.Config(np.random.RandomState(33),128)
In [9]: rstate=np.random.RandomState(33)
In [10]: co= T.Config(rstate,128)
In [11]: T.do_gaussian(co,'rslice','multi',rstate=rstate)
/home/skoposov/curwork/dynesty/py/dynesty/sampler.py:807: RuntimeWarning: overflow encountered in double_scalars
  math.exp(loglstar_new - logz_new) * loglstar_new)
/home/skoposov/curwork/dynesty/py/dynesty/sampler.py:810: RuntimeWarning: invalid value encountered in double_scalars
  dh = h_new - h
/home/skoposov/curwork/dynesty/py/dynesty/sampler.py:806: RuntimeWarning: overflow encountered in double_scalars
  lzterm = (math.exp(loglstar - logz_new) * loglstar +
....
/home/skoposov/curwork/dynesty/py/dynesty/sampler.py:807: RuntimeWarning: overflow encountered in double_scalars
  math.exp(loglstar_new - logz_new) * loglstar_new)
/home/skoposov/curwork/dynesty/py/dynesty/sampler.py:810: RuntimeWarning: invalid value encountered in double_scalars
  dh = h_new - h
---------------------------------------------------------------------------
OverflowError                             Traceback (most recent call last)
<ipython-input-11-cdc64999aaef> in <module>
----> 1 T.do_gaussian(co,'rslice','multi',rstate=rstate)

~/curwork/dynesty/tests/test_highdim.py in do_gaussian(co, sample, bound, rstate)
     74                                            rstate=rstate,
     75                                            vol_dec=.25)
---> 76     sampler.run_nested(print_progress=printing)
     77     res = sampler.results
     78     return res.logz[-1], res.logzerr[-1]

~/curwork/dynesty/py/dynesty/dynamicsampler.py in run_nested(self, nlive_init, maxiter_init, maxcall_init, dlogz_init, logl_max_init, n_effective_init, nlive_batch, wt_function, wt_kwargs, maxiter_batch, maxcall_batch, maxiter, maxcall, maxbatch, n_effective, stop_function, stop_kwargs, use_stop, save_bounds, print_progress, print_func, live_points)
   1554         try:
   1555             if not self.base:
-> 1556                 for results in self.sample_initial(
   1557                         nlive=nlive_init,
   1558                         dlogz=dlogz_init,

~/curwork/dynesty/py/dynesty/dynamicsampler.py in sample_initial(self, nlive, update_interval, first_update, maxiter, maxcall, logl_max, dlogz, n_effective, live_points, save_samples, resume)
    793         # Run the sampler internally as a generator.
    794         for i in range(1):
--> 795             for it, results in enumerate(
    796                     self.sampler.sample(maxiter=maxiter,
    797                                         save_samples=save_samples,

~/curwork/dynesty/py/dynesty/sampler.py in sample(self, maxiter, maxcall, dlogz, logl_max, n_effective, add_live, save_bounds, save_samples)
    805             logz_new = np.logaddexp(logz, logwt)
    806             lzterm = (math.exp(loglstar - logz_new) * loglstar +
--> 807                       math.exp(loglstar_new - logz_new) * loglstar_new)
    808             h_new = (math.exp(logdvol) * lzterm + math.exp(logz - logz_new) *
    809                      (h + logz) - logz_new)

OverflowError: math range error
```