### PR TITLE
Kwargs fix

### DIFF
--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -135,8 +135,7 @@ def NestedSampler(loglikelihood,
                   update_func=None,
                   ncdim=None,
                   save_history=False,
-                  history_filename=None,
-                  **kwargs):
+                  history_filename=None):
     """
     Initializes and returns a sampler object for Static Nested Sampling.
 
@@ -391,6 +390,7 @@ def NestedSampler(loglikelihood,
     if sample not in _SAMPLING and not callable(sample):
         raise ValueError("Unknown sampling method: '{0}'".format(sample))
 
+    kwargs = {}
     # Custom updating function.
     if update_func is not None and not callable(update_func):
         raise ValueError("Unknown update function: '{0}'".format(update_func))
@@ -605,6 +605,7 @@ def NestedSampler(loglikelihood,
 def DynamicNestedSampler(loglikelihood,
                          prior_transform,
                          ndim,
+                         nlive=None,
                          bound='multi',
                          sample='auto',
                          periodic=None,
@@ -634,8 +635,7 @@ def DynamicNestedSampler(loglikelihood,
                          update_func=None,
                          ncdim=None,
                          save_history=False,
-                         history_filename=None,
-                         **kwargs):
+                         history_filename=None):
     """
     Initializes and returns a sampler object for Dynamic Nested Sampling.
 
@@ -853,6 +853,8 @@ def DynamicNestedSampler(loglikelihood,
     if ncdim is None:
         ncdim = npdim
 
+    nlive = nlive or 500
+
     # Bounding method.
     if bound not in _SAMPLERS:
         raise ValueError("Unknown bounding method: '{0}'".format(bound))
@@ -872,6 +874,7 @@ def DynamicNestedSampler(loglikelihood,
     if ncdim != npdim and sample in ['slice', 'hslice', 'rslice']:
         raise ValueError('ncdim unsupported for slice sampling')
 
+    kwargs = {}
     # Custom sampling function.
     if sample not in _SAMPLING and not callable(sample):
         raise ValueError("Unknown sampling method: '{0}'".format(sample))
@@ -1011,7 +1014,7 @@ def DynamicNestedSampler(loglikelihood,
     # Initialize our nested sampler.
     sampler = DynamicSampler(loglike, ptform, npdim, bound, sample,
                              update_interval, first_update, rstate, queue_size,
-                             pool, use_pool, ncdim, kwargs)
+                             pool, use_pool, ncdim, nlive, kwargs)
 
     return sampler
 

--- a/tests/test_dyn.py
+++ b/tests/test_dyn.py
@@ -5,7 +5,7 @@ from utils import get_rstate
 Run a series of basic tests of the 2d eggbox
 """
 
-nlive = 100
+nlive = 500
 printing = False
 
 # EGGBOX

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -107,11 +107,3 @@ def test_livepoints():
                                     rstate=rstate)
     sampler.run_nested()
     dyutil.unravel_run(sampler.results)
-
-    sampler = dynesty.DynamicNestedSampler(loglike,
-                                           prior_transform,
-                                           ndim,
-                                           nlive=nlive,
-                                           live_points=live_points,
-                                           rstate=rstate)
-    sampler.run_nested(dlogz_init=1, maxcall=1000)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,6 +1,7 @@
 import numpy as np
 import dynesty
 import dynesty.utils as dyutil
+from utils import get_rstate
 """
 Run a series of basic tests changing various things like
 maxcall options and potentially other things
@@ -30,10 +31,12 @@ def test_maxcall():
     # hard test of dynamic sampler with high dlogz_init and small number
     # of live points
     ndim = 2
+    rstate = get_rstate()
     sampler = dynesty.NestedSampler(loglike,
                                     prior_transform,
                                     ndim,
-                                    nlive=nlive)
+                                    nlive=nlive,
+                                    rstate=rstate)
     sampler.run_nested(dlogz=1, maxcall=1000)
 
     sampler = dynesty.DynamicNestedSampler(loglike,
@@ -47,16 +50,19 @@ def test_inf():
     # hard test of dynamic sampler with high dlogz_init and small number
     # of live points
     ndim = 2
+    rstate = get_rstate()
     sampler = dynesty.NestedSampler(loglike_inf,
                                     prior_transform,
                                     ndim,
-                                    nlive=nlive)
+                                    nlive=nlive,
+                                    rstate=rstate)
     sampler.run_nested()
 
     sampler = dynesty.DynamicNestedSampler(loglike_inf,
                                            prior_transform,
                                            ndim,
-                                           nlive=nlive)
+                                           nlive=nlive,
+                                           rstate=rstate)
     sampler.run_nested(dlogz_init=1)
 
 
@@ -64,17 +70,20 @@ def test_unravel():
     # hard test of dynamic sampler with high dlogz_init and small number
     # of live points
     ndim = 2
+    rstate = get_rstate()
     sampler = dynesty.NestedSampler(loglike,
                                     prior_transform,
                                     ndim,
-                                    nlive=nlive)
+                                    nlive=nlive,
+                                    rstate=rstate)
     sampler.run_nested()
     dyutil.unravel_run(sampler.results)
 
     sampler = dynesty.DynamicNestedSampler(loglike,
                                            prior_transform,
                                            ndim,
-                                           nlive=nlive)
+                                           nlive=nlive,
+                                           rstate=rstate)
     sampler.run_nested(dlogz_init=1, maxcall=1000)
     dyutil.unravel_run(sampler.results)
     logps = sampler.results.logl
@@ -85,7 +94,8 @@ def test_livepoints():
     # hard test of dynamic sampler with high dlogz_init and small number
     # of live points
     ndim = 2
-    live_u = np.random.uniform(size=(ndim, 2))
+    rstate = get_rstate()
+    live_u = rstate.uniform(size=(ndim, 2))
     live_v = np.array([prior_transform(_) for _ in live_u])
     live_logl = np.array([loglike(_) for _ in live_v])
     live_points = [live_u, live_v, live_logl]
@@ -93,7 +103,8 @@ def test_livepoints():
                                     prior_transform,
                                     ndim,
                                     nlive=nlive,
-                                    live_points=live_points)
+                                    live_points=live_points,
+                                    rstate=rstate)
     sampler.run_nested()
     dyutil.unravel_run(sampler.results)
 
@@ -101,5 +112,6 @@ def test_livepoints():
                                            prior_transform,
                                            ndim,
                                            nlive=nlive,
-                                           live_points=live_points)
+                                           live_points=live_points,
+                                           rstate=rstate)
     sampler.run_nested(dlogz_init=1, maxcall=1000)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,11 +10,12 @@ potentially rare behaviour
 '''
 
 
-def get_rstate():
-    kw = 'DYNESTY_TEST_RANDOMSEED'
-    if kw in os.environ:
-        seed = int(os.environ[kw])
-    else:
-        seed = 56432
-    # seed the random number generator
+def get_rstate(seed=None):
+    if seed is None:
+        kw = 'DYNESTY_TEST_RANDOMSEED'
+        if kw in os.environ:
+            seed = int(os.environ[kw])
+        else:
+            seed = 56432
+        # seed the random number generator
     return np.random.default_rng(seed)


### PR DESCRIPTION
Attempt to address #293 
1) I remove **kwargs from Nested and Dynamic samplers
2) add nlive parameter to Dynamic samplers that will be used as default nlive_init/nlive_batch if those are not specified.
