### PR TITLE
Namedtuple iterator change

### DIFF
--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -633,7 +633,7 @@ class MultiEllipsoid:
         # using Monte Carlo integration.
         if mc_integrate:
             self.logvol, self.funit = self.monte_carlo_logvol(
-                return_overlap=True)
+                rstate=rstate, return_overlap=True)
 
 
 class RadFriends:
@@ -879,7 +879,7 @@ class RadFriends:
         # using Monte Carlo integration.
         if mc_integrate:
             self.logvol, self.funit = self.monte_carlo_logvol(
-                points, return_overlap=True)
+                points, return_overlap=True, rstate=rstate)
 
     def _get_covariance_from_all_points(self, points):
         """Compute covariance using all points."""
@@ -1158,7 +1158,7 @@ class SupFriends:
         # using Monte Carlo integration.
         if mc_integrate:
             self.logvol, self.funit = self.monte_carlo_logvol(
-                points, return_overlap=True)
+                points, return_overlap=True, rstate=rstate)
 
     def _get_covariance_from_all_points(self, points):
         """Compute covariance using all points."""

--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -496,7 +496,7 @@ class MultiEllipsoid:
             else:
                 # If `q` is not being returned, assume the user wants this
                 # done internally so we repeat the loop if needed
-                if rstate.uniform() < (1. / q):
+                if q == 1 or rstate.uniform() < (1. / q):
                     return x, idx
 
     def samples(self, nsamples, rstate=None):

--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -1227,7 +1227,7 @@ def randsphere(n, rstate=None):
 
 
 def rand_choice(pb, rstate):
-    """ Optimized version of np.random.choice
+    """ Optimized version of numpy's random.choice
     Return an index of a point selected with the probability pb
     The pb must sum to 1
     """

--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -881,8 +881,9 @@ class RadFriends:
         # Estimate the volume and fractional overlap with the unit cube
         # using Monte Carlo integration.
         if mc_integrate:
-            self.logvol, self.funit = self.monte_carlo_logvol(
-                points, return_overlap=True, rstate=rstate)
+            self.funit = self.monte_carlo_logvol(points,
+                                                 return_overlap=True,
+                                                 rstate=rstate)[1]
 
     def _get_covariance_from_all_points(self, points):
         """Compute covariance using all points."""
@@ -946,6 +947,7 @@ class SupFriends:
         assert detsign > 0
         self.logvol_cube = self.n * np.log(2.) - 0.5 * detln
         self.expand = 1.
+        self.funit = 1
 
     def scale_to_logvol(self, logvol):
         """Scale cube to encompass a target volume."""
@@ -1160,8 +1162,9 @@ class SupFriends:
         # Estimate the volume and fractional overlap with the unit cube
         # using Monte Carlo integration.
         if mc_integrate:
-            self.logvol, self.funit = self.monte_carlo_logvol(
-                points, return_overlap=True, rstate=rstate)
+            self.funit = self.monte_carlo_logvol(points,
+                                                 return_overlap=True,
+                                                 rstate=rstate)[1]
 
     def _get_covariance_from_all_points(self, points):
         """Compute covariance using all points."""

--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -342,7 +342,7 @@ class Ellipsoid:
         # Estimate the fractional overlap with the unit cube using
         # Monte Carlo integration.
         if mc_integrate:
-            self.funit = self.unitcube_overlap()
+            self.funit = self.unitcube_overlap(rstate=rstate)
 
 
 class MultiEllipsoid:

--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -477,7 +477,7 @@ class MultiEllipsoid:
         probs = np.exp(self.logvols - self.logvol_tot)
         while True:
             # Select an ellipsoid at random proportional to its volume.
-            idx = rstate.choice(self.nells, p=probs)
+            idx = rand_choice(probs, rstate)
 
             # Select a point from the chosen ellipsoid.
             x = self.ells[idx].sample(rstate=rstate)
@@ -1224,6 +1224,16 @@ def randsphere(n, rstate=None):
     z = rstate.standard_normal(size=n)  # initial n-dim vector
     xhat = z * (rstate.uniform()**(1. / n) / lalg.norm(z))  # scale
     return xhat
+
+
+def rand_choice(pb, rstate):
+    """ Optimized version of np.random.choice
+    Return an index of a point selected with the probability pb
+    The pb must sum to 1
+    """
+    p1 = np.cumsum(pb)
+    xr = rstate.uniform()
+    return min(np.searchsorted(p1, xr), len(pb) - 1)
 
 
 def improve_covar_mat(covar0, ntries=100, max_condition_number=1e12):

--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -163,6 +163,7 @@ class Ellipsoid:
         # Amount by which volume was increased after initialization (i.e.
         # cumulative factor from `scale_to_vol`).
         self.expand = 1.
+        self.funit = 1
 
     def scale_to_logvol(self, logvol):
         """Scale ellipsoid to a target volume."""
@@ -389,6 +390,7 @@ class MultiEllipsoid:
         self.expands = np.ones(self.nells)
         self.logvol_tot = logsumexp(self.logvols)
         self.expand_tot = 1.
+        self.funit = 1
 
     def __update_arrays(self):
         """
@@ -632,7 +634,7 @@ class MultiEllipsoid:
         # Estimate the volume and fractional overlap with the unit cube
         # using Monte Carlo integration.
         if mc_integrate:
-            self.logvol, self.funit = self.monte_carlo_logvol(
+            self.logvol_tot, self.funit = self.monte_carlo_logvol(
                 rstate=rstate, return_overlap=True)
 
 
@@ -663,6 +665,7 @@ class RadFriends:
         assert detsign > 0
         self.logvol_ball = (logvol_prefactor(self.n) - 0.5 * detln)
         self.expand = 1.
+        self.funit = 1
 
     def scale_to_logvol(self, logvol):
         """Scale ball to encompass a target volume."""

--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -1227,9 +1227,7 @@ def randsphere(n, rstate=None):
     """Draw a point uniformly within an `n`-dimensional unit sphere."""
 
     z = rstate.standard_normal(size=n)  # initial n-dim vector
-    zhat = z / lalg.norm(z)  # normalize
-    xhat = zhat * rstate.uniform()**(1. / n)  # scale
-
+    xhat = z * (rstate.uniform()**(1. / n) / lalg.norm(z))  # scale
     return xhat
 
 

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -24,7 +24,7 @@ from .nestedsamplers import (UnitCubeSampler, SingleEllipsoidSampler,
 from .results import Results
 from .utils import (get_seed_sequence, get_print_func, kld_error,
                     get_random_generator, compute_integrals, IteratorResult,
-                    IteratorResultShort)
+                    IteratorResultShort, get_enlarge_bootstrap)
 
 __all__ = [
     "DynamicSampler", "weight_function", "stopping_function", "_kld_error"
@@ -440,17 +440,10 @@ class DynamicSampler:
 
         # extra arguments
         self.kwargs = kwargs
-        if kwargs.get('bootstrap') is None:
-            if self.method == 'unif':
-                self.bootstrap = 20
-            else:
-                self.bootstrap = 0
-        else:
-            self.bootstrap = kwargs.get('bootstrap')
-        if self.bootstrap > 0:
-            self.enlarge = kwargs.get('enlarge', 1.0)
-        else:
-            self.enlarge = kwargs.get('enlarge', 1.25)
+
+        self.enlarge, self.bootstrap = get_enlarge_bootstrap(
+            method, kwargs.get('enlarge'), kwargs.get('bootstrap'))
+
         self.walks = self.kwargs.get('walks', 25)
         self.slices = self.kwargs.get('slices', 3)
         self.cite = self.kwargs.get('cite')

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -1155,6 +1155,8 @@ class DynamicSampler:
                                    'n_pt_above: %d' % (n_pt_above) +
                                    'n_pos_weight: %d' % (n_pos_weight) +
                                    'cur_wt: %s' % str(cur_wt))
+            # We are doing copies here, because live_* stuff is
+            # updated in place
             live_u = saved_u[subset, :].copy()
             live_v = saved_v[subset, :].copy()
             live_logl = saved_logl[subset].copy()
@@ -1206,11 +1208,14 @@ class DynamicSampler:
         # Overwrite the previous set of live points in our internal sampler
         # with the new batch of points we just generated.
         self.sampler.nlive = nlive_new
-        self.sampler.live_u = np.asarray(live_u)
-        self.sampler.live_v = np.asarray(live_v)
-        self.sampler.live_logl = np.asarray(live_logl)
-        self.sampler.live_bound = np.asarray(live_bound)
-        self.sampler.live_it = np.asarray(live_it)
+
+        # All the arrays are newly created in this function
+        # We don't need to worry about them being parts of other arrays
+        self.sampler.live_u = live_u
+        self.sampler.live_v = live_v
+        self.sampler.live_logl = live_logl
+        self.sampler.live_bound = live_bound
+        self.sampler.live_it = live_it
 
         # Trigger an update of the internal bounding distribution (again).
         live_logl_min = min(live_logl)
@@ -1255,11 +1260,7 @@ class DynamicSampler:
                                         maxcall=maxcall - sum(live_nc),
                                         save_samples=False,
                                         save_bounds=save_bounds)):
-
-                # Grab results.
-
                 # Save results.
-
                 D = dict(id=results.worst,
                          u=results.ustar,
                          v=results.vstar,
@@ -1293,8 +1294,6 @@ class DynamicSampler:
                               'You may not have enough livepoints')
 
             for it, results in enumerate(self.sampler.add_live_points()):
-                # Grab results.
-
                 # Save results.
                 D = dict(id=results.worst,
                          u=results.ustar,

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -758,14 +758,14 @@ class DynamicSampler:
                         self.live_v = np.array(
                             list(
                                 self.M(self.prior_transform,
-                                       np.array(self.live_u))))
+                                       np.asarray(self.live_u))))
                     else:
                         self.live_v = np.array(
                             list(
                                 map(self.prior_transform,
-                                    np.array(self.live_u))))
+                                    np.asarray(self.live_u))))
                     self.live_logl = np.array(
-                        self.loglikelihood.map(np.array(self.live_v)))
+                        self.loglikelihood.map(np.asarray(self.live_v)))
 
                     # Convert all `-np.inf` log-likelihoods to finite large
                     # numbers. Necessary to keep estimators in our sampler from
@@ -1067,16 +1067,16 @@ class DynamicSampler:
             live_u = self.rstate.uniform(size=(nlive_new, self.npdim))
             if self.use_pool_ptform:
                 live_v = np.array(
-                    list(self.M(self.prior_transform, np.array(live_u))))
+                    list(self.M(self.prior_transform, np.asarray(live_u))))
             else:
                 live_v = np.array(
-                    list(map(self.prior_transform, np.array(live_u))))
+                    list(map(self.prior_transform, np.asarray(live_u))))
             if self.use_pool_logl:
                 live_logl = np.array(
-                    list(self.M(self.loglikelihood, np.array(live_v))))
+                    list(self.M(self.loglikelihood, np.asarray(live_v))))
             else:
                 live_logl = np.array(
-                    list(map(self.loglikelihood, np.array(live_v))))
+                    list(map(self.loglikelihood, np.asarray(live_v))))
             # Convert all `-np.inf` log-likelihoods to finite large numbers.
             # Necessary to keep estimators in our sampler from breaking.
             for i, logl in enumerate(live_logl):
@@ -1206,11 +1206,11 @@ class DynamicSampler:
         # Overwrite the previous set of live points in our internal sampler
         # with the new batch of points we just generated.
         self.sampler.nlive = nlive_new
-        self.sampler.live_u = np.array(live_u)
-        self.sampler.live_v = np.array(live_v)
-        self.sampler.live_logl = np.array(live_logl)
-        self.sampler.live_bound = np.array(live_bound)
-        self.sampler.live_it = np.array(live_it)
+        self.sampler.live_u = np.asarray(live_u)
+        self.sampler.live_v = np.asarray(live_v)
+        self.sampler.live_logl = np.asarray(live_logl)
+        self.sampler.live_bound = np.asarray(live_bound)
+        self.sampler.live_it = np.asarray(live_it)
 
         # Trigger an update of the internal bounding distribution (again).
         live_logl_min = min(live_logl)

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -16,7 +16,7 @@ import numpy as np
 from .nestedsamplers import _SAMPLING
 from .dynamicsampler import (DynamicSampler, __get_update_interval_ratio,
                              _SAMPLERS)
-from .utils import LogLikelihood, get_random_generator
+from .utils import LogLikelihood, get_random_generator, get_enlarge_bootstrap
 
 __all__ = ["NestedSampler", "DynamicNestedSampler", "_function_wrapper"]
 
@@ -166,7 +166,7 @@ def NestedSampler(loglikelihood,
                   grad_kwargs=None,
                   compute_jac=False,
                   enlarge=None,
-                  bootstrap=0,
+                  bootstrap=None,
                   walks=None,
                   facc=0.5,
                   slices=None,
@@ -353,7 +353,8 @@ def NestedSampler(loglikelihood,
         Compute this many bootstrapped realizations of the bounding
         objects. Use the maximum distance found to the set of points left
         out during each iteration to enlarge the resulting volumes. Can
-        lead to unstable bounding ellipsoids. Default is `0` (no bootstrap).
+        lead to unstable bounding ellipsoids. Default is `None` (no bootstrap
+        unless the sampler is uniform).
 
     walks : int, optional
         For the `'rwalk'` sampling option, the minimum number of steps
@@ -479,10 +480,9 @@ def NestedSampler(loglikelihood,
         grad_kwargs = {}
 
     # Bounding distribution modifications.
-    if enlarge is not None:
-        kwargs['enlarge'] = enlarge
-    if bootstrap is not None:
-        kwargs['bootstrap'] = bootstrap
+    enlarge, bootstrap = get_enlarge_bootstrap(sample, enlarge, bootstrap)
+    kwargs['enlarge'] = enlarge
+    kwargs['bootstrap'] = bootstrap
 
     # Sampling.
     if walks is not None:
@@ -646,7 +646,7 @@ def DynamicNestedSampler(loglikelihood,
                          grad_kwargs=None,
                          compute_jac=False,
                          enlarge=None,
-                         bootstrap=0,
+                         bootstrap=None,
                          walks=None,
                          facc=0.5,
                          slices=None,
@@ -819,7 +819,8 @@ def DynamicNestedSampler(loglikelihood,
         Compute this many bootstrapped realizations of the bounding
         objects. Use the maximum distance found to the set of points left
         out during each iteration to enlarge the resulting volumes. Can lead
-        to unstable bounding ellipsoids. Default is `0` (no bootstrap).
+        to unstable bounding ellipsoids. Default is `None` (no bootstrap unless
+        the sampler is uniform).
 
     walks : int, optional
         For the `'rwalk'` sampling option, the minimum number of steps
@@ -947,10 +948,9 @@ def DynamicNestedSampler(loglikelihood,
         grad_kwargs = {}
 
     # Bounding distribution modifications.
-    if enlarge is not None:
-        kwargs['enlarge'] = enlarge
-    if bootstrap is not None:
-        kwargs['bootstrap'] = bootstrap
+    enlarge, bootstrap = get_enlarge_bootstrap(sample, enlarge, bootstrap)
+    kwargs['enlarge'] = enlarge
+    kwargs['bootstrap'] = bootstrap
 
     # Sampling.
     if walks is not None:

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -444,11 +444,15 @@ def NestedSampler(loglikelihood,
         if np.intersect1d(periodic, reflective) != 0:
             raise ValueError("You have specified a parameter as both "
                              "periodic and reflective.")
-    nonbounded = np.ones(npdim, dtype='bool')
-    if periodic is not None:
-        nonbounded[periodic] = False
-    if reflective is not None:
-        nonbounded[reflective] = False
+
+    if periodic is not None or reflective is not None:
+        nonbounded = np.ones(npdim, dtype='bool')
+        if periodic is not None:
+            nonbounded[periodic] = False
+        if reflective is not None:
+            nonbounded[reflective] = False
+    else:
+        nonbounded = None
     kwargs['nonbounded'] = nonbounded
     kwargs['periodic'] = periodic
     kwargs['reflective'] = reflective
@@ -912,11 +916,16 @@ def DynamicNestedSampler(loglikelihood,
         if np.intersect1d(periodic, reflective) != 0:
             raise ValueError("You have specified a parameter as both "
                              "periodic and reflective.")
-    nonbounded = np.ones(npdim, dtype='bool')
-    if periodic is not None:
-        nonbounded[periodic] = False
-    if reflective is not None:
-        nonbounded[reflective] = False
+
+    if periodic is not None or reflective is not None:
+        nonbounded = np.ones(npdim, dtype='bool')
+        if periodic is not None:
+            nonbounded[periodic] = False
+        if reflective is not None:
+            nonbounded[reflective] = False
+    else:
+        nonbounded = None
+
     kwargs['nonbounded'] = nonbounded
     kwargs['periodic'] = periodic
     kwargs['reflective'] = reflective

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -389,7 +389,6 @@ class SingleEllipsoidSampler(SuperSampler):
 
         self.ell = Ellipsoid(np.zeros(self.ncdim), np.identity(self.ncdim))
         self.bounding = 'single'
-        self.method = method
 
     def update(self):
         """Update the bounding ellipsoid using the current set of

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -281,8 +281,9 @@ class UnitCubeSampler(SuperSampler):
 
         u = self.unitcube.sample(rstate=self.rstate)
         ax = np.identity(self.npdim)
-        u = np.concatenate(
-            [u, self.rstate.uniform(0, 1, self.npdim - self.ncdim)])
+        if self.npdim != self.ncdim:
+            u = np.concatenate(
+                [u, self.rstate.uniform(0, 1, self.npdim - self.ncdim)])
 
         return u, ax
 
@@ -421,9 +422,9 @@ class SingleEllipsoidSampler(SuperSampler):
             # Check if `u` is within the unit cube.
             if unitcheck(u, self.nonbounded):
                 break  # if it is, we're done!
-
-        u = np.concatenate(
-            [u, self.rstate.uniform(0, 1, self.npdim - self.ncdim)])
+        if self.npdim != self.ncdim:
+            u = np.concatenate(
+                [u, self.rstate.uniform(0, 1, self.npdim - self.ncdim)])
         return u, self.ell.axes
 
     def propose_live(self, *args):
@@ -905,9 +906,9 @@ class SupFriendsSampler(SuperSampler):
 
         # Define the axes of our N-cube.
         ax = self.supfriends.axes
-
-        u = np.concatenate(
-            [u, self.rstate.uniform(0, 1, self.npdim - self.ncdim)])
+        if self.npdim != self.ncdim:
+            u = np.concatenate(
+                [u, self.rstate.uniform(0, 1, self.npdim - self.ncdim)])
         return u, ax
 
     def propose_live(self, *args):

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -133,6 +133,12 @@ class SuperSampler(Sampler):
         self.fmove = self.kwargs.get('fmove', 0.9)
         self.max_move = self.kwargs.get('max_move', 100)
 
+    def propose_unif(self, *args):
+        pass
+
+    def propose_live(self, *args):
+        pass
+
     def update_unif(self, blob):
         """Filler function."""
         pass

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -559,6 +559,10 @@ class MultiEllipsoidSampler(SuperSampler):
         """Propose a new live point by sampling *uniformly* within
         the union of ellipsoids."""
 
+        if self.ncdim != self.npdim and self.nonbounded is not None:
+            nonb = self.nonbounded[:self.ncdim]
+        else:
+            nonb = self.nonbounded
         while True:
             # Sample a point from the union of ellipsoids.
             # Returns the point `u`, ellipsoid index `idx`, and number of
@@ -568,7 +572,7 @@ class MultiEllipsoidSampler(SuperSampler):
                 # Accept the point with probability 1/q to account for
                 # overlapping ellipsoids.
                 # Check if the point is within the unit cube.
-                if unitcheck(u, self.nonbounded[:self.ncdim]):
+                if unitcheck(u, nonb):
                     break  # if successful, we're done!
         if self.ncdim != self.npdim:
             u = np.concatenate(

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -95,6 +95,9 @@ class SuperSampler(Sampler):
             method = "user-defined"
         self.propose_point = self._PROPOSE[method]
 
+        # Initialize method to "evolve" a point to a new position.
+        self.sampling, self.evolve_point = method, _SAMPLING[method]
+
         # Initialize heuristic used to update our sampling method.
         self._UPDATE = {
             'unif': self.update_unif,
@@ -105,8 +108,10 @@ class SuperSampler(Sampler):
             'hslice': self.update_hslice,
             'user-defined': self.update_user
         }
-        self.kwargs = kwargs or {}
+        # Initialize other arguments.
+        self.scale = 1.
 
+        self.kwargs = kwargs or {}
         # please use self.kwargs below
 
         self.custom_update = self.kwargs.get('update_func')
@@ -262,12 +267,6 @@ class UnitCubeSampler(SuperSampler):
                          ncdim=ncdim,
                          kwargs=kwargs or {})
 
-        # Initialize method to "evolve" a point to a new position.
-        self.sampling, self.evolve_point = method, _SAMPLING[method]
-
-        # Initialize other arguments.
-        self.scale = 1.
-
         self.unitcube = UnitCube(self.ncdim)
         self.bounding = 'none'
 
@@ -386,12 +385,6 @@ class SingleEllipsoidSampler(SuperSampler):
                          use_pool,
                          ncdim=ncdim,
                          kwargs=kwargs or {})
-
-        # Initialize method to "evolve" a point to a new position.
-        self.sampling, self.evolve_point = method, _SAMPLING[method]
-
-        # Initialize other arguments.
-        self.scale = 1.
 
         self.ell = Ellipsoid(np.zeros(self.ncdim), np.identity(self.ncdim))
         self.bounding = 'single'
@@ -537,12 +530,6 @@ class MultiEllipsoidSampler(SuperSampler):
                          use_pool,
                          ncdim=ncdim,
                          kwargs=kwargs or {})
-
-        # Initialize method to "evolve" a point to a new position.
-        self.sampling, self.evolve_point = method, _SAMPLING[method]
-
-        # Initialize other arguments.
-        self.scale = 1.
 
         self.mell = MultiEllipsoid(ctrs=[np.zeros(self.ncdim)],
                                    covs=[np.identity(self.ncdim)])
@@ -721,11 +708,6 @@ class RadFriendsSampler(SuperSampler):
                          ncdim=ncdim,
                          kwargs=kwargs or {})
 
-        # Initialize method to "evolve" a point to a new position.
-        self.sampling, self.evolve_point = method, _SAMPLING[method]
-
-        # Initialize other arguments.
-        self.scale = 1.
         self.radfriends = RadFriends(self.ncdim)
         self.bounding = 'balls'
 
@@ -874,12 +856,6 @@ class SupFriendsSampler(SuperSampler):
                          use_pool,
                          ncdim=ncdim,
                          kwargs=kwargs or {})
-
-        # Initialize method to "evolve" a point to a new position.
-        self.sampling, self.evolve_point = method, _SAMPLING[method]
-
-        # Initialize other arguments.
-        self.scale = 1.
 
         self.supfriends = SupFriends(self.ncdim)
         self.bounding = 'cubes'

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -567,13 +567,10 @@ class MultiEllipsoidSampler(SuperSampler):
             # Sample a point from the union of ellipsoids.
             # Returns the point `u`, ellipsoid index `idx`, and number of
             # overlapping ellipsoids `q` at position `u`.
-            u, idx, q = self.mell.sample(rstate=self.rstate, return_q=True)
-            if q == 1 or self.rstate.uniform() < 1.0 / q:
-                # Accept the point with probability 1/q to account for
-                # overlapping ellipsoids.
-                # Check if the point is within the unit cube.
-                if unitcheck(u, nonb):
-                    break  # if successful, we're done!
+            u, idx = self.mell.sample(rstate=self.rstate)
+            # Check if the point is within the unit cube.
+            if unitcheck(u, nonb):
+                break  # if successful, we're done!
         if self.ncdim != self.npdim:
             u = np.concatenate(
                 [u, self.rstate.uniform(0, 1, self.npdim - self.ncdim)])

--- a/py/dynesty/plotting.py
+++ b/py/dynesty/plotting.py
@@ -1610,11 +1610,14 @@ def boundplot(results,
     nsamps = len(results['samples'])
 
     # Gather boundary conditions.
-    nonbounded = np.ones(bounds[0].n, dtype='bool')
-    if periodic is not None:
-        nonbounded[periodic] = False
-    if reflective is not None:
-        nonbounded[reflective] = False
+    if periodic is not None or reflective is not None:
+        nonbounded = np.ones(bounds[0].n, dtype='bool')
+        if periodic is not None:
+            nonbounded[periodic] = False
+        if reflective is not None:
+            nonbounded[reflective] = False
+    else:
+        nonbounded = None
 
     if it is not None:
         if it >= nsamps:
@@ -1937,16 +1940,19 @@ def cornerbound(results,
     # Extract bounding distributions.
     try:
         bounds = results['bound']
-    except:
+    except KeyError:
         raise ValueError("No bounds were saved in the results!")
     nsamps = len(results['samples'])
 
     # Gather boundary conditions.
-    nonbounded = np.ones(bounds[0].n, dtype='bool')
-    if periodic is not None:
-        nonbounded[periodic] = False
-    if reflective is not None:
-        nonbounded[reflective] = False
+    if periodic is not None or reflective is not None:
+        nonbounded = np.ones(bounds[0].n, dtype='bool')
+        if periodic is not None:
+            nonbounded[periodic] = False
+        if reflective is not None:
+            nonbounded[reflective] = False
+    else:
+        nonbounded = None
 
     if it is not None:
         if it >= nsamps:
@@ -1955,7 +1961,7 @@ def cornerbound(results,
         # Extract bound iterations.
         try:
             bound_iter = np.array(results['bound_iter'])
-        except:
+        except KeyError:
             raise ValueError("Cannot reconstruct the bound used at the "
                              "specified iteration since bound "
                              "iterations were not saved in the results.")

--- a/py/dynesty/results.py
+++ b/py/dynesty/results.py
@@ -110,8 +110,13 @@ def get_print_fn_args(results,
                       logl_min=-np.inf,
                       logl_max=np.inf):
     # Extract results at the current iteration.
-    (worst, ustar, vstar, loglstar, logvol, logwt, logz, logzvar, h, nc,
-     worst_it, boundidx, bounditer, eff, delta_logz) = results
+    loglstar = results.loglstar
+    logz = results.logz
+    logzvar = results.logzvar
+    delta_logz = results.delta_logz
+    bounditer = results.bounditer
+    nc = results.nc
+    eff = results.eff
 
     # Adjusting outputs for printing.
     if delta_logz > 1e6:

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -201,12 +201,12 @@ class Sampler:
         if self.use_pool_ptform:
             # Use the pool to compute the prior transform.
             self.live_v = np.array(
-                list(self.M(self.prior_transform, np.array(self.live_u))))
+                list(self.M(self.prior_transform, np.asarray(self.live_u))))
         else:
             # Compute the prior transform using the default `map` function.
             self.live_v = np.array(
-                list(map(self.prior_transform, np.array(self.live_u))))
-        self.live_logl = self.loglikelihood.map(np.array(self.live_v))
+                list(map(self.prior_transform, np.asarray(self.live_u))))
+        self.live_logl = self.loglikelihood.map(np.asarray(self.live_v))
 
         self.live_bound = np.zeros(self.nlive, dtype='int')
         self.live_it = np.zeros(self.nlive, dtype='int')
@@ -480,8 +480,8 @@ class Sampler:
             # ancillary quantities.
             idx = lsort_idx[i]
             logvol, dlv = logvols[i], dlvs[i]
-            ustar = np.array(self.live_u[idx])
-            vstar = np.array(self.live_v[idx])
+            ustar = np.asarray(self.live_u[idx])
+            vstar = np.asarray(self.live_v[idx])
             loglstar_new = self.live_logl[idx]
             boundidx = self.live_bound[idx]
             point_it = self.live_it[idx]
@@ -775,8 +775,8 @@ class Sampler:
             boundidx = self.live_bound[worst]  # associated bound index
 
             # Set our new worst likelihood constraint.
-            ustar = np.array(self.live_u[worst])  # unit cube position
-            vstar = np.array(self.live_v[worst])  # transformed position
+            ustar = np.asarray(self.live_u[worst])  # unit cube position
+            vstar = np.asarray(self.live_v[worst])  # transformed position
             loglstar_new = self.live_logl[worst]  # new likelihood
 
             # Sample a new live point from within the likelihood constraint

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -480,8 +480,10 @@ class Sampler:
             # ancillary quantities.
             idx = lsort_idx[i]
             logvol, dlv = logvols[i], dlvs[i]
-            ustar = np.asarray(self.live_u[idx])
-            vstar = np.asarray(self.live_v[idx])
+            # we are doing copies here, because live_u/live_v are
+            # updated in place
+            ustar = self.live_u[idx].copy()
+            vstar = self.live_v[idx].copy()
             loglstar_new = self.live_logl[idx]
             boundidx = self.live_bound[idx]
             point_it = self.live_it[idx]
@@ -775,8 +777,10 @@ class Sampler:
             boundidx = self.live_bound[worst]  # associated bound index
 
             # Set our new worst likelihood constraint.
-            ustar = np.asarray(self.live_u[worst])  # unit cube position
-            vstar = np.asarray(self.live_v[worst])  # transformed position
+            # Notice we are doing copies here because live_u and live_v
+            # are updated in-place
+            ustar = self.live_u[worst].copy()  # unit cube position
+            vstar = self.live_v[worst].copy()  # transformed position
             loglstar_new = self.live_logl[worst]  # new likelihood
 
             # Sample a new live point from within the likelihood constraint

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -170,7 +170,7 @@ class Sampler:
     def update_proposal(self, *args):
         raise RuntimeError('Should be overriden')
 
-    def update(self, *args):
+    def update(self):
         raise RuntimeError('Should be overriden')
 
     def __getstate__(self):

--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -83,8 +83,8 @@ def sample_unif(args):
      kwargs) = args
 
     # Evaluate.
-    v = prior_transform(np.array(u))
-    logl = loglikelihood(np.array(v))
+    v = prior_transform(np.asarray(u))
+    logl = loglikelihood(np.asarray(v))
     nc = 1
     blob = None
 
@@ -223,8 +223,8 @@ def sample_rwalk(args):
                 scale *= math.exp(-1. / n_cluster)
 
         # Check proposed point.
-        v_prop = prior_transform(np.array(u_prop))
-        logl_prop = loglikelihood(np.array(v_prop))
+        v_prop = prior_transform(np.asarray(u_prop))
+        logl_prop = loglikelihood(np.asarray(v_prop))
         if logl_prop > loglstar:
             u = u_prop
             v = v_prop
@@ -384,8 +384,8 @@ def sample_rstagger(args):
                 scale *= math.exp(-1. / n_cluster)
 
         # Check proposed point.
-        v_prop = prior_transform(np.array(u_prop))
-        logl_prop = loglikelihood(np.array(v_prop))
+        v_prop = prior_transform(np.asarray(u_prop))
+        logl_prop = loglikelihood(np.asarray(v_prop))
         if logl_prop > loglstar:
             u = u_prop
             v = v_prop
@@ -838,8 +838,8 @@ def sample_hslice(args):
                 u_r += rstate.uniform(1. - jitter, 1. + jitter) * vel
                 # Evaluate point.
                 if unitcheck(u_r, nonperiodic):
-                    v_r = prior_transform(np.array(u_r))
-                    logl_r = loglikelihood(np.array(v_r))
+                    v_r = prior_transform(np.asarray(u_r))
+                    logl_r = loglikelihood(np.asarray(v_r))
                     nc += 1
                     ncall += 1
                     nmove += 1
@@ -895,8 +895,8 @@ def sample_hslice(args):
                     # right side
                     u_r_r[i] += 1e-10
                     if unitcheck(u_r_r, nonperiodic):
-                        v_r_r = prior_transform(np.array(u_r_r))
-                        logl_r_r = loglikelihood(np.array(v_r_r))
+                        v_r_r = prior_transform(np.asarray(u_r_r))
+                        logl_r_r = loglikelihood(np.asarray(v_r_r))
                     else:
                         logl_r_r = -np.inf
                         reverse = True  # can't compute gradient
@@ -904,8 +904,8 @@ def sample_hslice(args):
                     # left side
                     u_r_l[i] -= 1e-10
                     if unitcheck(u_r_l, nonperiodic):
-                        v_r_l = prior_transform(np.array(u_r_l))
-                        logl_r_l = loglikelihood(np.array(v_r_l))
+                        v_r_l = prior_transform(np.asarray(u_r_l))
+                        logl_r_l = loglikelihood(np.asarray(v_r_l))
                     else:
                         logl_r_l = -np.inf
                         reverse = True  # can't compute gradient
@@ -926,14 +926,14 @@ def sample_hslice(args):
                         # right side
                         u_r_r[i] += 1e-10
                         if unitcheck(u_r_r, nonperiodic):
-                            v_r_r = prior_transform(np.array(u_r_r))
+                            v_r_r = prior_transform(np.asarray(u_r_r))
                         else:
                             reverse = True  # can't compute Jacobian
                             v_r_r = np.array(v_r)  # assume no movement
                         # left side
                         u_r_l[i] -= 1e-10
                         if unitcheck(u_r_l, nonperiodic):
-                            v_r_l = prior_transform(np.array(u_r_l))
+                            v_r_l = prior_transform(np.asarray(u_r_l))
                         else:
                             reverse = True  # can't compute Jacobian
                             v_r_r = np.array(v_r)  # assume no movement
@@ -977,8 +977,8 @@ def sample_hslice(args):
                 u_l += rstate.uniform(1. - jitter, 1. + jitter) * vel
                 # Evaluate point.
                 if unitcheck(u_l, nonperiodic):
-                    v_l = prior_transform(np.array(u_l))
-                    logl_l = loglikelihood(np.array(v_l))
+                    v_l = prior_transform(np.asarray(u_l))
+                    logl_l = loglikelihood(np.asarray(v_l))
                     nc += 1
                     ncall += 1
                     nmove += 1
@@ -1034,8 +1034,8 @@ def sample_hslice(args):
                     # right side
                     u_l_r[i] += 1e-10
                     if unitcheck(u_l_r, nonperiodic):
-                        v_l_r = prior_transform(np.array(u_l_r))
-                        logl_l_r = loglikelihood(np.array(v_l_r))
+                        v_l_r = prior_transform(np.asarray(u_l_r))
+                        logl_l_r = loglikelihood(np.asarray(v_l_r))
                     else:
                         logl_l_r = -np.inf
                         reverse = True  # can't compute gradient
@@ -1043,8 +1043,8 @@ def sample_hslice(args):
                     # left side
                     u_l_l[i] -= 1e-10
                     if unitcheck(u_l_l, nonperiodic):
-                        v_l_l = prior_transform(np.array(u_l_l))
-                        logl_l_l = loglikelihood(np.array(v_l_l))
+                        v_l_l = prior_transform(np.asarray(u_l_l))
+                        logl_l_l = loglikelihood(np.asarray(v_l_l))
                     else:
                         logl_l_l = -np.inf
                         reverse = True  # can't compute gradient
@@ -1065,14 +1065,14 @@ def sample_hslice(args):
                         # right side
                         u_l_r[i] += 1e-10
                         if unitcheck(u_l_r, nonperiodic):
-                            v_l_r = prior_transform(np.array(u_l_r))
+                            v_l_r = prior_transform(np.asarray(u_l_r))
                         else:
                             reverse = True  # can't compute Jacobian
                             v_l_r = np.array(v_l)  # assume no movement
                         # left side
                         u_l_l[i] -= 1e-10
                         if unitcheck(u_l_l, nonperiodic):
-                            v_l_l = prior_transform(np.array(u_l_l))
+                            v_l_l = prior_transform(np.asarray(u_l_l))
                         else:
                             reverse = True  # can't compute Jacobian
                             v_l_r = np.array(v_l)  # assume no movement
@@ -1136,8 +1136,8 @@ def sample_hslice(args):
             rprop = rstate.uniform()
             u_prop = u_l + rprop * u_hat  # scale from left
             if unitcheck(u_prop, nonperiodic):
-                v_prop = prior_transform(np.array(u_prop))
-                logl_prop = loglikelihood(np.array(v_prop))
+                v_prop = prior_transform(np.asarray(u_prop))
+                logl_prop = loglikelihood(np.asarray(v_prop))
             else:
                 logl_prop = -np.inf
             nc += 1

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -133,6 +133,7 @@ class LogLikelihood:
         import h5py
         try:
             with h5py.File(self.history_filename, mode='a') as fp:
+                # pylint: disable=no-member
                 nadd = len(self.history_logl)
                 fp['param'].resize(self.history_counter + nadd, axis=0)
                 fp['logl'].resize(self.history_counter + nadd, axis=0)
@@ -599,8 +600,11 @@ def compute_integrals(logl=None, logvol=None, reweight=None):
     reweight: array (or None)
         (optional) reweighting array to reweight posterior
     """
+    # pylint: disable=invalid-unary-operand-type
+    # Unfortunately pylint doesn't get the asserts
     assert logl is not None
     assert logvol is not None
+
     loglstar_pad = np.concatenate([[-1.e300], logl])
 
     # we want log(exp(logvol_i)-exp(logvol_(i+1)))

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -9,7 +9,7 @@ import sys
 import warnings
 import math
 import copy
-import collections
+from collections import namedtuple
 from functools import partial
 import numpy as np
 from scipy.special import logsumexp
@@ -29,21 +29,15 @@ __all__ = [
 
 SQRTEPS = math.sqrt(float(np.finfo(np.float64).eps))
 
-IteratorResult = collections.namedtuple('IteratorResult', [
+IteratorResult = namedtuple('IteratorResult', [
     'worst', 'ustar', 'vstar', 'loglstar', 'logvol', 'logwt', 'logz',
     'logzvar', 'h', 'nc', 'worst_it', 'boundidx', 'bounditer', 'eff',
     'delta_logz'
 ])
-IteratorResultShort = collections.namedtuple('IteratorResult', [
-    'worst',
-    'ustar',
-    'vstar',
-    'loglstar',
-    'nc',
-    'worst_it',
-    'boundidx',
-    'bounditer',
-    'eff',
+
+IteratorResultShort = namedtuple('IteratorResult', [
+    'worst', 'ustar', 'vstar', 'loglstar', 'nc', 'worst_it', 'boundidx',
+    'bounditer', 'eff'
 ])
 
 

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -215,14 +215,14 @@ def unitcheck(u, nonbounded=None):
 
     if nonbounded is None:
         # No periodic boundary conditions provided.
-        return np.all(u > 0.) and np.all(u < 1.)
+        return np.min(u) > 0 and np.max(u) < 1
     else:
         # Alternating periodic and non-periodic boundary conditions.
         unb = u[nonbounded]
         # pylint: disable=invalid-unary-operand-type
         ub = u[~nonbounded]
-        return (np.all(unb > 0.) and np.all(unb < 1.) and np.all(ub > -0.5)
-                and np.all(ub < 1.5))
+        return (unb.min() > 0 and unb.max() < 1 and ub.min() > -0.5
+                and ub.max() < 1.5)
 
 
 def apply_reflect(u):

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -9,6 +9,7 @@ import sys
 import warnings
 import math
 import copy
+import collections
 from functools import partial
 import numpy as np
 from scipy.special import logsumexp
@@ -28,6 +29,23 @@ __all__ = [
 ]
 
 SQRTEPS = math.sqrt(float(np.finfo(np.float64).eps))
+
+IteratorResult = collections.namedtuple('IteratorResult', [
+    'worst', 'ustar', 'vstar', 'loglstar', 'logvol', 'logwt', 'logz',
+    'logzvar', 'h', 'nc', 'worst_it', 'boundidx', 'bounditer', 'eff',
+    'delta_logz'
+])
+IteratorResultShort = collections.namedtuple('IteratorResult', [
+    'worst',
+    'ustar',
+    'vstar',
+    'loglstar',
+    'nc',
+    'worst_it',
+    'boundidx',
+    'bounditer',
+    'eff',
+])
 
 
 class LogLikelihood:

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -340,7 +340,7 @@ def resample_equal(samples, weights, rstate=None):
         # same tol as in numpy's random.choice.
         # Guarantee that the weights will sum to 1.
         warnings.warn("Weights do not sum to 1 and have been renormalized.")
-        weights = np.array(weights) / np.sum(weights)
+        weights = np.asarray(weights) / np.sum(weights)
 
     # Make N subdivisions and choose positions with a consistent random offset.
     nsamples = len(weights)
@@ -831,14 +831,14 @@ def resample_run(res, rstate=None, return_idx=False):
     new_res.samples_it = res.samples_it[samp_idx]
     new_res.samples_u = res.samples_u[samp_idx]
     new_res.samples_n = samp_n
-    new_res.logwt = np.array(saved_logwt)
+    new_res.logwt = np.asarray(saved_logwt)
     new_res.logl = logl
     new_res.logvol = logvol
-    new_res.logz = np.array(saved_logz)
+    new_res.logz = np.asarray(saved_logz)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        new_res.logzerr = np.sqrt(np.array(saved_logzvar))
-    new_res.h = np.array(saved_h)
+        new_res.logzerr = np.sqrt(np.asarray(saved_logzvar))
+    new_res.h = np.asarray(saved_h)
 
     if return_idx:
         return new_res, samp_idx
@@ -931,10 +931,10 @@ def reweight_run(res, logp_new, logp_old=None):
     new_res = Results(list(res.items()))
 
     # Overwrite items with our new estimates.
-    new_res.logwt = np.array(saved_logwt)
-    new_res.logz = np.array(saved_logz)
-    new_res.logzerr = np.sqrt(np.array(saved_logzvar))
-    new_res.h = np.array(saved_h)
+    new_res.logwt = np.asarray(saved_logwt)
+    new_res.logz = np.asarray(saved_logz)
+    new_res.logzerr = np.sqrt(np.asarray(saved_logzvar))
+    new_res.h = np.asarray(saved_h)
 
     return new_res
 
@@ -1456,23 +1456,23 @@ def _merge_two(res1, res2, compute_aux=False):
     eff = 100. * ntot / sum(combined_nc)
 
     # Save results.
-    r = [('niter', ntot), ('ncall', np.array(combined_nc)), ('eff', eff),
-         ('samples', np.array(combined_v)),
-         ('samples_id', np.array(combined_id)),
-         ('samples_it', np.array(combined_it)),
-         ('samples_n', np.array(combined_n)),
-         ('samples_u', np.array(combined_u)),
-         ('samples_batch', np.array(combined_batch)),
-         ('logl', np.array(combined_logl)),
-         ('logvol', np.array(combined_logvol)),
-         ('batch_bounds', np.array(bounds))]
+    r = [('niter', ntot), ('ncall', np.asarray(combined_nc)), ('eff', eff),
+         ('samples', np.asarray(combined_v)),
+         ('samples_id', np.asarray(combined_id)),
+         ('samples_it', np.asarray(combined_it)),
+         ('samples_n', np.asarray(combined_n)),
+         ('samples_u', np.asarray(combined_u)),
+         ('samples_batch', np.asarray(combined_batch)),
+         ('logl', np.asarray(combined_logl)),
+         ('logvol', np.asarray(combined_logvol)),
+         ('batch_bounds', np.asarray(bounds))]
 
     # Add proposal information (if available).
     if base_proposals and new_proposals:
         r.append(('prop', prop))
-        r.append(('prop_iter', np.array(combined_piter)))
-        r.append(('samples_prop', np.array(combined_propidx)))
-        r.append(('scale', np.array(combined_scale)))
+        r.append(('prop_iter', np.asarray(combined_piter)))
+        r.append(('samples_prop', np.asarray(combined_propidx)))
+        r.append(('scale', np.asarray(combined_scale)))
 
     # Compute the posterior quantities of interest if desired.
     if compute_aux:
@@ -1482,17 +1482,17 @@ def _merge_two(res1, res2, compute_aux=False):
                                          logl=combined_logl)
 
         # Compute batch information.
-        combined_id = np.array(combined_id)
+        combined_id = np.asarray(combined_id)
         batch_nlive = [
             len(np.unique(combined_id[combined_batch == i]))
             for i in np.unique(combined_batch)
         ]
 
         # Add to our results.
-        r.append(('logwt', (combined_logwt)))
-        r.append(('logz', (combined_logz)))
-        r.append(('logzerr', np.sqrt((combined_logzvar))))
-        r.append(('h', (combined_h)))
+        r.append(('logwt', combined_logwt))
+        r.append(('logz', combined_logz))
+        r.append(('logzerr', np.sqrt(combined_logzvar)))
+        r.append(('h', combined_h))
         r.append(('batch_nlive', np.array(batch_nlive, dtype=int)))
 
     # Combine to form final results object.

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -24,7 +24,8 @@ from .results import Results, print_fn
 __all__ = [
     "unitcheck", "resample_equal", "mean_and_cov", "quantile", "jitter_run",
     "resample_run", "simulate_run", "reweight_run", "unravel_run",
-    "merge_runs", "kld_error", "_merge_two", "_get_nsamps_samples_n"
+    "merge_runs", "kld_error", "_merge_two", "_get_nsamps_samples_n",
+    "get_enlarge_bootstrap"
 ]
 
 SQRTEPS = math.sqrt(float(np.finfo(np.float64).eps))
@@ -150,6 +151,32 @@ class LogLikelihood:
         state = self.__dict__.copy()
         del state['pool']
         return state
+
+
+def get_enlarge_bootstrap(sample, enlarge, bootstrap):
+    """
+    Determine the enlarge, boostrap for a given run
+    """
+    # we should make it dimension dependent I think...
+    DEFAULT_ENLARGE = 1.25
+    DEFAULT_UNIF_BOOTSTRAP = 5
+    if enlarge is not None and bootstrap is None:
+        assert enlarge > 1
+        return enlarge, 0
+    elif enlarge is None and bootstrap is not None:
+        assert bootstrap > 1
+        return 1, bootstrap
+    elif enlarge is None and bootstrap is None:
+        if sample == 'unif':
+            return 1, DEFAULT_UNIF_BOOTSTRAP
+        else:
+            return DEFAULT_ENLARGE, 0
+    else:
+        if bootstrap == 0 or enlarge == 1:
+            return enlarge, bootstrap
+        else:
+            raise ValueError('Enlarge and bootstrap together do not make'
+                             'sense unless bootstrap=1 or enlarge = 1')
 
 
 def get_print_func(print_func, print_progress):

--- a/tests/test_dyn.py
+++ b/tests/test_dyn.py
@@ -21,20 +21,21 @@ def prior_transform_egg(x):
     return x * 10 * np.pi
 
 
+LOGZ_TRUTH = 235.856
+
+
 def test_dyn():
     # hard test of dynamic sampler with high dlogz_init and small number
     # of live points
     ndim = 2
-    bound = 'multi'
+    THRESHOLD = 5  # in sigmas
     rstate = get_rstate()
+    # this is expected to use unif sampler and multi bound
     sampler = dynesty.DynamicNestedSampler(loglike_egg,
                                            prior_transform_egg,
                                            ndim,
                                            nlive=nlive,
-                                           bound=bound,
-                                           sample='unif',
                                            rstate=rstate)
     sampler.run_nested(dlogz_init=1, print_progress=printing)
-    logz_truth = 235.856
-    assert (abs(logz_truth - sampler.results.logz[-1]) <
-            5. * sampler.results.logzerr[-1])
+    assert (abs(LOGZ_TRUTH - sampler.results.logz[-1]) <
+            THRESHOLD * sampler.results.logzerr[-1])

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -104,7 +104,7 @@ def test_livepoints():
     # Test the providing of initial live-points to the sampler
     ndim = 2
     rstate = get_rstate()
-    live_u = rstate.uniform(size=(ndim, 2))
+    live_u = rstate.uniform(size=(nlive, ndim))
     live_v = np.array([prior_transform(_) for _ in live_u])
     live_logl = np.array([loglike(_) for _ in live_v])
     live_points = [live_u, live_v, live_logl]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -118,26 +118,6 @@ def test_livepoints():
     dyutil.unravel_run(sampler.results)
 
 
-def test_kl():
-    # Test the providing of initial live-points to the sampler
-    ndim = 2
-    rstate = get_rstate()
-    sampler1 = dynesty.NestedSampler(loglike,
-                                     prior_transform,
-                                     ndim,
-                                     nlive=nlive,
-                                     rstate=rstate)
-    sampler1.run_nested()
-    res1 = sampler1.results
-    res2 = dyutil.resample_run(res1, rstate=rstate)
-    kl = dyutil.kl_divergence(res2, res1)
-    # TODO Curretly KL>0 divergence check fails
-    # assert kl[-1] > 0
-    assert np.isfinite(kl[-1])
-    with pytest.raises(Exception):
-        dyutil.kl_divergence(res1, res2)
-
-
 def test_exc():
     # Test of exceptions that the exception is reraised
     ndim = 2

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -11,9 +11,20 @@ Run a series of basic tests to check whether anything huge is broken.
 nlive = 1000
 printing = False
 
+ndim = 2
+gau_s = 0.01
+
+
+def loglike_gau(x):
+    return (-0.5 * np.log(2 * np.pi) * ndim - np.log(gau_s) * ndim -
+            0.5 * np.sum(x**2) / gau_s**2)
+
+
+def prior_transform_gau(x):
+    return x
+
+
 # EGGBOX
-
-
 # see 1306.2144
 def loglike_egg(x):
     logl = ((2 + np.cos(x[0] / 2) * np.cos(x[1] / 2))**5)
@@ -24,66 +35,56 @@ def prior_transform_egg(x):
     return x * 10 * np.pi
 
 
+LOGZ_TRUTH_GAU = 0
+LOGZ_TRUTH_EGG = 235.856
+
+
 def test_pool():
-    # test pool
-    ndim = 2
+    # test pool on egg problem
     pool = mp.Pool(2)
     rstate = get_rstate()
     sampler = dynesty.NestedSampler(loglike_egg,
                                     prior_transform_egg,
                                     ndim,
                                     nlive=nlive,
-                                    bound='multi',
-                                    sample='unif',
                                     pool=pool,
                                     queue_size=2,
                                     rstate=rstate)
     sampler.run_nested(dlogz=0.1, print_progress=printing)
-    logz_truth = 235.856
-    assert (abs(logz_truth - sampler.results.logz[-1]) <
+    assert (abs(LOGZ_TRUTH_EGG - sampler.results.logz[-1]) <
             5. * sampler.results.logzerr[-1])
 
 
 def test_pool_dynamic():
-    # test pool
-    ndim = 2
+    # test pool in dynamic mode
+    # here for speed I do a gaussian
     pool = mp.Pool(2)
     rstate = get_rstate()
-    sampler = dynesty.DynamicNestedSampler(loglike_egg,
-                                           prior_transform_egg,
+    sampler = dynesty.DynamicNestedSampler(loglike_gau,
+                                           prior_transform_gau,
                                            ndim,
                                            nlive=nlive,
-                                           bound='multi',
-                                           sample='unif',
                                            pool=pool,
                                            queue_size=2,
                                            rstate=rstate)
-    sampler.run_nested(print_progress=printing)
-    logz_truth = 235.856
-    assert (abs(logz_truth - sampler.results.logz[-1]) <
+    sampler.run_nested(dlogz_init=1, print_progress=printing)
+    assert (abs(LOGZ_TRUTH_GAU - sampler.results.logz[-1]) <
             5. * sampler.results.logzerr[-1])
 
 
-size = 3
+POOL_KW = ['prior_transform', 'loglikelihood', 'propose_point', 'update_bound']
 
 
-def loglike_gau(x):
-    return -0.5 * np.sum(x**2)
-
-
-def prior_transform_gau(x):
-    return (2 * x - 1) * size
-
-
-@pytest.mark.parametrize(
-    'func',
-    ['prior_transform', 'loglikelihood', 'propose_point', 'update_bound'])
+@pytest.mark.parametrize('func', POOL_KW)
 def test_usepool(func):
-    ndim = 2
+    # test all the use_pool options, toggle them one by one
     rstate = get_rstate()
     pool = mp.Pool(2)
+    use_pool = {}
+    for k in POOL_KW:
+        use_pool[k] = False
+    use_pool[func] = True
 
-    use_pool = {func: True}
     sampler = dynesty.DynamicNestedSampler(loglike_gau,
                                            prior_transform_gau,
                                            ndim,
@@ -91,5 +92,5 @@ def test_usepool(func):
                                            rstate=rstate,
                                            use_pool=use_pool,
                                            pool=pool,
-                                           queue_size=20)
+                                           queue_size=2)
     sampler.run_nested(maxiter=10000)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -17,7 +17,7 @@ gau_s = 0.01
 
 def loglike_gau(x):
     return (-0.5 * np.log(2 * np.pi) * ndim - np.log(gau_s) * ndim -
-            0.5 * np.sum(x**2) / gau_s**2)
+            0.5 * np.sum((x - 0.5)**2) / gau_s**2)
 
 
 def prior_transform_gau(x):


### PR DESCRIPTION
Although it could have been an option after 1.2, I thought addressing #307 is worthwhile as currently things are error-prone. 
now all the iterators return namedtuples and I think the code is cleaner. There is a fair bit of repeated code stuff and it may be refactored in the future, but it looks worth applying. 

I've also yanked the kl_divergence.

 
