### PR TITLE
Batch fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,10 +44,10 @@ jobs:
       - name: TestWithCov
         # Run coverage only for 3.6
         if: ${{ matrix.python-version == '3.6'}}
-        run: pytest --durations=0 --cov=dynesty
+        run: pytest --durations=0  -m "not slow" --cov=dynesty
       - name: Test
         if: ${{ matrix.python-version != '3.6'}}
-        run: pytest --durations=0
+        run: pytest --durations=0  -m "not slow"
       - name: Coveralls
         if: ${{ success() && ( matrix.python-version == '3.6') }}
         run: coveralls --service=github

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -1255,13 +1255,16 @@ class DynamicSampler:
 
         # Update internal ln(prior volume)-based quantities
         if self.new_logl_min == -np.inf:
-            bound_logvol = 0.
+            vol_idx = 0
         else:
             vol_idx = np.argmin(
-                abs(self.saved_run.D['logl'] - self.new_logl_min))
-            bound_logvol = self.saved_run.D['logvol'][vol_idx]
+                abs(self.saved_run.D['logl'] - self.new_logl_min)) + 1
+
+        # truncate information in the saver of the internal sampler
+        for k in self.sampler.saved_run.D.keys():
+            self.sampler.saved_run.D[k] = self.saved_run.D[k][:vol_idx]
         bound_dlv = math.log((nlive_new + 1.) / nlive_new)
-        self.sampler.saved_run.D['logvol'][-1] = bound_logvol
+
         self.sampler.dlv = bound_dlv
 
         # Tell the sampler *not* to try and remove the previous addition of

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -1253,7 +1253,9 @@ class DynamicSampler:
             vol_idx = 0
         else:
             vol_idx = np.argmin(
-                np.abs(self.saved_run.D['logl'] - self.new_logl_min)) + 1
+                np.abs(
+                    np.asarray(self.saved_run.D['logl']) -
+                    self.new_logl_min)) + 1
 
         # truncate information in the saver of the internal sampler
         for k in batch_sampler.saved_run.D.keys():

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -1193,7 +1193,7 @@ class DynamicSampler:
             # Trigger an update of the internal bounding distribution based
             # on the "new" set of live points.
 
-            live_logl_min = min(live_logl)
+            live_logl_min = np.min(live_logl)
             if batch_sampler._beyond_unit_bound(live_logl_min):
                 bound = batch_sampler.update()
                 if save_bounds:
@@ -1238,11 +1238,11 @@ class DynamicSampler:
         batch_sampler.live_logl = live_logl
         batch_sampler.live_bound = live_bound
         batch_sampler.live_it = live_it
-
+        batch_sampler.it = self.it + 1
         # Trigger an update of the internal bounding distribution (again).
         live_logl_min = min(live_logl)
         if batch_sampler._beyond_unit_bound(live_logl_min):
-            bound = batch_sampler.update()  # vol / nlive_new)
+            bound = batch_sampler.update()
             if save_bounds:
                 batch_sampler.bound.append(copy.deepcopy(bound))
             batch_sampler.nbound += 1
@@ -1256,14 +1256,13 @@ class DynamicSampler:
             vol_idx = 0
         else:
             vol_idx = np.argmin(
-                abs(self.saved_run.D['logl'] - self.new_logl_min)) + 1
+                np.abs(self.saved_run.D['logl'] - self.new_logl_min)) + 1
 
         # truncate information in the saver of the internal sampler
         for k in batch_sampler.saved_run.D.keys():
             batch_sampler.saved_run.D[k] = self.saved_run.D[k][:vol_idx]
-        bound_dlv = math.log((nlive_new + 1.) / nlive_new)
 
-        batch_sampler.dlv = bound_dlv
+        batch_sampler.dlv = math.log((nlive_new + 1.) / nlive_new)
 
         # Tell the sampler *not* to try and remove the previous addition of
         # live points. All the hacks above make the internal results

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -1083,30 +1083,16 @@ class DynamicSampler:
         if psel:
             # If the lower bound encompasses all saved samples, we want
             # to propose a new set of points from the unit cube.
-            live_u = self.rstate.uniform(size=(nlive_new, self.npdim))
-            if self.use_pool_ptform:
-                live_v = np.array(
-                    list(self.M(self.prior_transform, np.asarray(live_u))))
-            else:
-                live_v = np.array(
-                    list(map(self.prior_transform, np.asarray(live_u))))
-            if self.use_pool_logl:
-                live_logl = np.array(
-                    list(self.M(self.loglikelihood, np.asarray(live_v))))
-            else:
-                live_logl = np.array(
-                    list(map(self.loglikelihood, np.asarray(live_v))))
-            # Convert all `-np.inf` log-likelihoods to finite large numbers.
-            # Necessary to keep estimators in our sampler from breaking.
-            for i, logl in enumerate(live_logl):
-                if not np.isfinite(logl):
-                    if np.sign(logl) < 0:
-                        live_logl[i] = _LOWL_VAL
-                    else:
-                        raise ValueError("The log-likelihood ({0}) of live "
-                                         "point {1} located at u={2} v={3} "
-                                         " is invalid.".format(
-                                             logl, i, live_u[i], live_v[i]))
+            live_u, live_v, live_logl = sample_init(
+                None,
+                self.prior_transform,
+                self.loglikelihood,
+                self.M,
+                nlive=nlive_new,
+                npdim=self.npdim,
+                rstate=self.rstate,
+                use_pool_ptform=self.use_pool_ptform)
+
             live_bound = np.zeros(nlive_new, dtype='int')
             live_it = np.zeros(nlive_new, dtype='int') + self.it
             live_nc = np.ones(nlive_new, dtype='int')

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -1193,22 +1193,19 @@ class DynamicSampler:
             # Trigger an update of the internal bounding distribution based
             # on the "new" set of live points.
 
-            live_logl_min = np.min(live_logl)
-            if batch_sampler._beyond_unit_bound(live_logl_min):
-                bound = batch_sampler.update()
-                if save_bounds:
-                    batch_sampler.bound.append(copy.deepcopy(bound))
-                batch_sampler.nbound += 1
-                batch_sampler.since_update = 0
-
+            bound = batch_sampler.update()
+            if save_bounds:
+                batch_sampler.bound.append(copy.deepcopy(bound))
+            batch_sampler.nbound += 1
+            batch_sampler.since_update = 0
+            batch_sampler.logl_first_update = logl_min
             # Sample a new batch of `nlive_new` live points using the
             # internal sampler given the `logl_min` constraint.
             live_u = np.empty((nlive_new, self.npdim))
             live_v = np.empty((nlive_new, saved_v.shape[1]))
             live_logl = np.empty(nlive_new)
             live_bound = np.zeros(nlive_new, dtype='int')
-            if batch_sampler._beyond_unit_bound(live_logl_min):
-                live_bound += batch_sampler.nbound - 1
+
             live_it = np.empty(nlive_new, dtype='int')
             live_nc = np.empty(nlive_new, dtype='int')
             for i in range(nlive_new):
@@ -1240,13 +1237,13 @@ class DynamicSampler:
         batch_sampler.live_it = live_it
         batch_sampler.it = self.it + 1
         # Trigger an update of the internal bounding distribution (again).
-        live_logl_min = min(live_logl)
-        if batch_sampler._beyond_unit_bound(live_logl_min):
+        if not psel:
             bound = batch_sampler.update()
             if save_bounds:
                 batch_sampler.bound.append(copy.deepcopy(bound))
             batch_sampler.nbound += 1
             batch_sampler.since_update = 0
+            batch_sampler.logl_first_update = logl_min
 
         # Copy over bound reference.
         self.bound = batch_sampler.bound

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -163,7 +163,8 @@ def weight_function(results, args=None, return_weights=False):
         logl_max = logl[min(bounds[1] - bounds[0], nsamps - 1)]
     else:
         logl_min, logl_max = logl[bounds[0]], logl[bounds[1]]
-
+    if bounds[1] == nsamps - 1:
+        logl_max = np.inf
     if return_weights:
         return (logl_min, logl_max), (pweight, zweight, weight)
     else:
@@ -1062,8 +1063,6 @@ class DynamicSampler:
         # Initialize ln(likelihood) bounds.
         if logl_bounds is None:
             logl_min, logl_max = -np.inf, max(saved_logl[:-nblive])
-            # why is logl_max defined this way ???
-            # why are we skipping top nblive points ?
         else:
             logl_min, logl_max = logl_bounds
         self.new_logl_min, self.new_logl_max = logl_min, logl_max
@@ -1314,7 +1313,8 @@ class DynamicSampler:
                                           bounditer=results.bounditer,
                                           eff=self.eff)
 
-            if iterated_batch and results.loglstar < logl_max:
+            if (iterated_batch and results.loglstar < logl_max
+                    and np.isfinite(logl_max)):
                 warnings.warn('Warning. The maximum likelihood not reached '
                               'in the batch. '
                               'You may not have enough livepoints')

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -184,7 +184,12 @@ class SuperSampler(Sampler):
         # https://www.tandfonline.com/doi/full/10.1080/10618600.2013.791193
         # and https://github.com/joshspeagle/dynesty/issues/260
         nexpand, ncontract = max(blob['nexpand'], 1), blob['ncontract']
-        self.scale *= nexpand * 2. / (nexpand + ncontract)
+        mult = (nexpand * 2. / (nexpand + ncontract))
+        # avoid drastic updates to the scale factor limiting to factor
+        # of two
+        mult = np.clip(mult, 0.5, 2)
+        # No need to set the scale to be larger than half cube diagonal
+        self.scale = np.minimum(self.scale * mult, np.sqrt(self.npdim) / 2.)
 
     def update_hslice(self, blob):
         """Update the Hamiltonian slice proposal scale based

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -188,8 +188,9 @@ class SuperSampler(Sampler):
         # avoid drastic updates to the scale factor limiting to factor
         # of two
         mult = np.clip(mult, 0.5, 2)
-        # No need to set the scale to be larger than half cube diagonal
-        self.scale = np.minimum(self.scale * mult, np.sqrt(self.npdim) / 2.)
+        # Remember I can't apply the rule that scale < cube diagonal
+        # because scale is multiplied by axes
+        self.scale = self.scale * mult
 
     def update_hslice(self, blob):
         """Update the Hamiltonian slice proposal scale based

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -347,8 +347,11 @@ class Sampler:
         if self.method != 'unif':
             args = (np.nonzero(self.live_logl > loglstar)[0], )
             if len(args[0]) == 0:
-                raise RuntimeError('No live points are above loglstar. '
-                                   'Do you have likelihood plateau ? ')
+                raise RuntimeError(
+                    'No live points are above loglstar. '
+                    'Do you have a likelihood plateau ? '
+                    'It is also possible that you are trying to sample '
+                    'excessively around the very peak of the posterior')
         else:
             args = ()
         while self.nqueue < self.queue_size:

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -316,7 +316,7 @@ class Sampler:
             # If we've already update our bounds, check if we've exceeded the
             # saved log-likelihood threshold. (This is useful when sampling
             # within `dynamicsampler`).
-            return loglstar > self.logl_first_update
+            return loglstar >= self.logl_first_update
 
     def _empty_queue(self):
         """Dump all live point proposals currently on the queue."""

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -669,7 +669,7 @@ class Sampler:
         ncall = 0
 
         # Check whether we're starting fresh or continuing a previous run.
-        if self.it == 1:
+        if self.it == 1 or len(self.saved_run.D['logl']) == 0:
             # Initialize values for nested sampling loop.
             h = 0.  # information, initially *0.*
             logz = -1.e300  # ln(evidence), initially *0.*

--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -344,8 +344,7 @@ def generic_slice_step(u, direction, nonperiodic, loglstar, loglikelihood,
     maxlen = np.sqrt(n) / 2.
     # maximum initial interval length (the diagonal of the cube)
     if dirlen > maxlen:
-        warnings.warn(
-            'The slice sampling interval is longer than the cube size')
+        # I stopped giving warnings, as it was too noisy
         dirnorm = dirlen / maxlen
     else:
         dirnorm = 1

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -162,17 +162,29 @@ def get_enlarge_bootstrap(sample, enlarge, bootstrap):
     DEFAULT_ENLARGE = 1.25
     DEFAULT_UNIF_BOOTSTRAP = 5
     if enlarge is not None and bootstrap is None:
-        assert enlarge > 1
+        """If enlarge is specified and bootstrap is not we just use enlarge
+        with no nootstrapping"""
+        assert enlarge >= 1
         return enlarge, 0
     elif enlarge is None and bootstrap is not None:
-        assert bootstrap > 1
+        """
+        If bootstrap is specified but enlarge is not we just use bootstrap
+        And if we allow zero bootstrap if we want to force no bootstrap
+        """
+        assert ((bootstrap > 1) or (bootstrap == 0))
         return 1, bootstrap
     elif enlarge is None and bootstrap is None:
+        """
+        If neither enlarge or bootstrap are specified we are doing
+        things in auto-mode. I.e. use enlarge unless the uniform
+        sampler is selected
+        """
         if sample == 'unif':
             return 1, DEFAULT_UNIF_BOOTSTRAP
         else:
             return DEFAULT_ENLARGE, 0
     else:
+        """Both enlarge and bootstrap were specified"""
         if bootstrap == 0 or enlarge == 1:
             return enlarge, bootstrap
         else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --strict-markers
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/test_dyn.py
+++ b/tests/test_dyn.py
@@ -1,12 +1,12 @@
 import numpy as np
 import dynesty
-from utils import get_rstate
+from utils import get_rstate, get_printing
 """
 Run a series of basic tests of the 2d eggbox
 """
 
 nlive = 500
-printing = False
+printing = get_printing()
 
 # EGGBOX
 

--- a/tests/test_dyn.py
+++ b/tests/test_dyn.py
@@ -21,7 +21,7 @@ def prior_transform_egg(x):
     return x * 10 * np.pi
 
 
-LOGZ_TRUTH = 235.856
+LOGZ_TRUTH = 235.855940
 
 
 def test_dyn():

--- a/tests/test_dyn.py
+++ b/tests/test_dyn.py
@@ -2,7 +2,7 @@ import numpy as np
 import dynesty
 from utils import get_rstate, get_printing
 """
-Run a series of basic tests of the 2d eggbox
+This is a hard test of dynamic sampling with the 2d eggbox
 """
 
 nlive = 500

--- a/tests/test_egg.py
+++ b/tests/test_egg.py
@@ -2,13 +2,13 @@ import numpy as np
 import dynesty
 import pytest
 import itertools
-from utils import get_rstate
+from utils import get_rstate, get_printing
 """
 Run a series of basic tests of the 2d eggbox
 """
 
 nlive = 1000
-printing = False
+printing = get_printing()
 
 # EGGBOX
 

--- a/tests/test_gau.py
+++ b/tests/test_gau.py
@@ -3,7 +3,7 @@ import pytest
 from numpy import linalg
 import numpy.testing as npt
 import itertools
-from utils import get_rstate
+from utils import get_rstate, get_printing
 import matplotlib
 
 matplotlib.use('Agg')
@@ -17,7 +17,7 @@ Run a series of basic tests to check whether anything huge is broken.
 """
 
 nlive = 500
-printing = False
+printing = get_printing()
 
 
 def bootstrap_tol(results, rstate):

--- a/tests/test_gau.py
+++ b/tests/test_gau.py
@@ -279,6 +279,9 @@ def test_dynamic():
                                             g.ndim,
                                             rstate=rstate)
     dsampler.run_nested(print_progress=printing)
+    # chechk explicit adding batches
+    dsampler.add_batch(logl_bounds=(-10, 0))
+    dsampler.add_batch(logl_bounds=(-10000000, -1000))
     check_results_gau(dsampler.results, g, rstate)
 
     # check error analysis functions

--- a/tests/test_highdim.py
+++ b/tests/test_highdim.py
@@ -3,13 +3,13 @@ from scipy import linalg
 import scipy.stats
 import dynesty
 import multiprocessing as mp
-from utils import get_rstate
+from utils import get_rstate, get_printing
 """
 Run a series of basic tests to check whether anything huge is broken.
 
 """
 
-printing = False
+printing = get_printing()
 
 
 def get_covar(rstate, ndim):

--- a/tests/test_highdim.py
+++ b/tests/test_highdim.py
@@ -1,6 +1,8 @@
+import itertools
 import numpy as np
 from scipy import linalg
 import scipy.stats
+import pytest
 import dynesty
 import multiprocessing as mp
 from utils import get_rstate, get_printing
@@ -118,3 +120,21 @@ def do_gaussians(sample='rslice',
     for ndim, co, curres in res:
         curres = curres.get()
         print(ndim, curres[0], curres[1], curres[2], co.logz_truth_gau)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("ndim,sample",
+                         list(
+                             itertools.product([10, 30],
+                                               ['rslice', 'rwalk', 'unif'])))
+def test_run(ndim, sample):
+    rstate = get_rstate(ndim)
+    co = Config(rstate, ndim)
+    nlive = 5000
+    bound = 'multi'
+    res = do_gaussian(co,
+                      sample=sample,
+                      bound=bound,
+                      rstate=rstate,
+                      nlive=nlive)
+    assert (np.abs(co.logz_truth_gau - res[1]) < 5 * res[2])

--- a/tests/test_ncdim.py
+++ b/tests/test_ncdim.py
@@ -3,13 +3,13 @@ from numpy import linalg
 import numpy.testing as npt
 import dynesty
 from dynesty import utils as dyfunc
-from utils import get_rstate
+from utils import get_rstate, get_printing
 """
 A rudimentary test that ncdim parameter works
 """
 
 nlive = 500
-printing = False
+printing = get_printing
 
 
 def bootstrap_tol(results, rstate):

--- a/tests/test_pathology.py
+++ b/tests/test_pathology.py
@@ -26,40 +26,26 @@ def prior_transform(x):
     return x * 2 - 1
 
 
-@pytest.mark.parametrize("bound,sample",
-                         itertools.product(['multi'],
+@pytest.mark.parametrize("dynamic,bound,sample",
+                         itertools.product([False, True], ['multi'],
                                            ['unif', 'rslice', 'rwalk']))
-def test_pathology(bound, sample):
+def test_pathology(dynamic, bound, sample):
     ndim = 2
     rstate = get_rstate()
-    sampler = dynesty.NestedSampler(loglike,
-                                    prior_transform,
-                                    ndim,
-                                    nlive=nlive,
-                                    bound=bound,
-                                    sample=sample,
-                                    rstate=rstate)
-    sampler.run_nested(dlogz=0.1, print_progress=printing)
-    logz_truth = np.log(1 - np.log(alpha))
-    # this the integral
-    logz, logzerr = sampler.results.logz[-1], sampler.results.logzerr[-1]
-    thresh = 4
-    assert (np.abs(logz - logz_truth) < thresh * logzerr)
-
-
-@pytest.mark.parametrize("bound,sample",
-                         itertools.product(['multi'], ['unif', 'rslice']))
-def test_pathology_dynamic(bound, sample):
-    ndim = 2
-    rstate = get_rstate()
-    sampler = dynesty.DynamicNestedSampler(loglike,
-                                           prior_transform,
-                                           ndim,
-                                           nlive=nlive,
-                                           bound=bound,
-                                           sample=sample,
-                                           rstate=rstate)
-    sampler.run_nested(dlogz_init=1, print_progress=printing)
+    if dynamic:
+        SAMPLER = dynesty.DynamicNestedSampler
+        kw = dict(dlogz_init=1)
+    else:
+        SAMPLER = dynesty.NestedSampler
+        kw = dict(dlogz=.1)
+    sampler = SAMPLER(loglike,
+                      prior_transform,
+                      ndim,
+                      nlive=nlive,
+                      bound=bound,
+                      sample=sample,
+                      rstate=rstate)
+    sampler.run_nested(print_progress=printing, **kw)
     logz_truth = np.log(1 - np.log(alpha))
     # this the integral
     logz, logzerr = sampler.results.logz[-1], sampler.results.logzerr[-1]

--- a/tests/test_pathology.py
+++ b/tests/test_pathology.py
@@ -3,10 +3,10 @@ import numpy as np
 import dynesty
 import pytest
 import itertools
-from utils import get_rstate
+from utils import get_rstate, get_printing
 
 nlive = 1000
-printing = False
+printing = get_printing()
 alpha = 1e-8
 
 

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -1,10 +1,10 @@
 import numpy as np
 import dynesty
 from scipy.special import erf
-from utils import get_rstate
+from utils import get_rstate, get_printing
 
 nlive = 100
-printing = True
+printing = get_printing()
 win = 100
 
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -2,14 +2,14 @@ import numpy as np
 import pytest
 import dynesty
 import multiprocessing as mp
-from utils import get_rstate
+from utils import get_rstate, get_printing
 """
 Run a series of basic tests to check whether anything huge is broken.
 
 """
 
 nlive = 1000
-printing = False
+printing = get_printing()
 
 ndim = 2
 gau_s = 0.01

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import dynesty
 from utils import get_rstate
 """
 Run a series of basic tests testing printing output

--- a/tests/test_saver.py
+++ b/tests/test_saver.py
@@ -3,7 +3,7 @@ import dynesty
 import os
 import multiprocessing as mp
 import pytest
-from utils import get_rstate
+from utils import get_rstate, get_printing
 """
 Run a series of basic tests to check whether saving likelikelihood evals
 are broken
@@ -11,7 +11,7 @@ are broken
 """
 
 nlive = 100
-printing = False
+printing = get_printing()
 
 # EGGBOX
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,3 +18,11 @@ def get_rstate(seed=None):
             seed = 56432
         # seed the random number generator
     return np.random.default_rng(seed)
+
+
+def get_printing():
+    kw = 'DYNESTY_TEST_PRINTING'
+    if kw in os.environ:
+        return int(os.environ[kw])
+    else:
+        return False


### PR DESCRIPTION
get rid of dlog_batch internal variable
put in the dlogz=0.01 function parameter (currently not available from the outside yet)
Also prevent spurious warnings in the case we are sampling the 'top' part of the posterior. In that case I set the upper logl limit to be +inf. And if that's the case I'm not checking that logl is above loglmax. 
addresses #325 