### PR TITLE
6x speed up within() method of multiellipsoid

### DIFF
--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -425,15 +425,13 @@ class MultiEllipsoid:
 
     def within(self, x, j=None):
         """Checks which ellipsoid(s) `x` falls within, skipping the `j`-th
-        ellipsoid."""
+        ellipsoid if need be."""
 
-        # Loop through distance calculations if there aren't too many.
-        idxs = np.where([
-            self.ells[i].contains(x) if i != j else True
-            for i in range(self.nells)
-        ])[0]
-
-        return idxs
+        delt = x[None, :] - self.ctrs
+        mask = np.einsum('ai,aij,aj->a', delt, self.ams, delt) < 1
+        if j is not None:
+            mask[j] = False
+        return np.nonzero(mask)[0]
 
     def overlap(self, x, j=None):
         """Checks how many ellipsoid(s) `x` falls within, skipping the `j`-th

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -229,7 +229,7 @@ def stopping_function(results,
     realizations of the input using a provided `'error'` keyword (either
     `'jitter'` or `'simulate'`, which call related functions :meth:`jitter_run`
     and :meth:`simulate_run` in :mod:`dynesty.utils`, respectively, or
-    `'sim_approx'`, which boosts `'jitter'` by a factor of two).
+    `'sim_approx'`
 
     Returns the boolean `stop <= 1`. If `True`, the :class:`DynamicSampler`
     will stop adding new samples to our results.
@@ -302,9 +302,6 @@ def stopping_function(results,
             "The chosen `'error'` option {0} is not valid.".format(error))
     if error == 'sim_approx':
         error = 'jitter'
-        boost = 2.
-    else:
-        boost = 1.
     approx = args.get('approx', True)
 
     # Compute realizations of ln(evidence) and the KL divergence.
@@ -319,11 +316,11 @@ def stopping_function(results,
 
     # Evidence stopping value.
     lnz_std = np.std(lnz_arr)
-    stop_evid = np.sqrt(boost) * lnz_std / evid_thresh
+    stop_evid = lnz_std / evid_thresh
 
     # Posterior stopping value.
     kld_mean, kld_std = np.mean(kld_arr), np.std(kld_arr)
-    stop_post = boost * (kld_std / kld_mean) / post_thresh
+    stop_post = (kld_std / kld_mean) / post_thresh
 
     # Effective stopping value.
     stop = pfrac * stop_post + (1. - pfrac) * stop_evid

--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -604,10 +604,10 @@ def sample_rslice(args):
         drhat /= linalg.norm(drhat)
 
         # Transform and scale based on past tuning.
-        axis = np.dot(axes, drhat) * scale
+        direction = np.dot(axes, drhat) * scale
 
         (u_prop, v_prop, logl_prop, nc1, nexpand1, ncontract1,
-         fscale1) = generic_slice_step(u, axis, nonperiodic, loglstar,
+         fscale1) = generic_slice_step(u, direction, nonperiodic, loglstar,
                                        loglikelihood, prior_transform, rstate)
         u = u_prop
         nc += nc1

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -847,9 +847,7 @@ def resample_run(res, rstate=None, return_idx=False):
     new_res.logl = logl
     new_res.logvol = logvol
     new_res.logz = np.asarray(saved_logz)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        new_res.logzerr = np.sqrt(np.asarray(saved_logzvar))
+    new_res.logzerr = np.sqrt(np.maximum(np.asarray(saved_logzvar), 0))
     new_res.h = np.asarray(saved_h)
 
     if return_idx:

--- a/tests/test_ellipsoid.py
+++ b/tests/test_ellipsoid.py
@@ -39,6 +39,7 @@ def test_sample(withq, ndim):
             R.append(mu.sample(rstate=rstate)[0])
     R = np.array(R)
     assert (all([mu.contains(_) for _ in R]))
+    assert (all([ells[0].contains(_) or ells[1].contains(_) for _ in R]))
 
     # here I'm checking that all the points are uniformly distributed
     # within each ellipsoid

--- a/tests/test_highdim.py
+++ b/tests/test_highdim.py
@@ -90,7 +90,7 @@ def do_gaussian(co,
                                            slices=slices)
     sampler.run_nested(print_progress=printing)
     res = sampler.results
-    return np.sum(res.ncall), res.logz[-1], res.logzerr[-1]
+    return np.sum(res.ncall), res.logz[-1], res.logzerr[-1], res
 
 
 def do_gaussians(sample='rslice',
@@ -128,7 +128,7 @@ def do_gaussians(sample='rslice',
                              itertools.product([10, 30],
                                                ['rslice', 'rwalk', 'unif'])))
 def test_run(ndim, sample):
-    rstate = get_rstate(ndim)
+    rstate = get_rstate()
     co = Config(rstate, ndim)
     nlive = 5000
     bound = 'multi'
@@ -138,3 +138,4 @@ def test_run(ndim, sample):
                       rstate=rstate,
                       nlive=nlive)
     assert (np.abs(co.logz_truth_gau - res[1]) < 5 * res[2])
+    return res[3]


### PR DESCRIPTION
Speeds up this by a factor of 6

```
import dynesty.bounding as db
import numpy as np

sig = np.identity(10)
cens = [(np.arange(10) == i).astype(int) for i in range(10)]
ells = db.MultiEllipsoid([db.Ellipsoid(xcen, sig) for xcen in cens])
x0 = np.zeros(10)
for i in range(1000000):
    ells.within(x0)
```
