### PR TITLE
add test for rstate

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -60,11 +60,12 @@ def test_maxcall():
     sampler.run_nested(dlogz_init=1, maxcall=1000)
 
 
-def test_rstate_setting():
+def test_same_rstate_produce_same_logz_for_differnt_runs():
     ndim = 2
     rstate = get_rstate()
+    n_runs = 10
     logzs = []
-    for _ in range(10):
+    for _ in range(n_runs):
         sampler = dynesty.NestedSampler(loglike,
                                         prior_transform,
                                         ndim,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -62,7 +62,7 @@ def test_maxcall():
 
 def test_rstate_setting():
     ndim = 2
-    rstate = np.random.RandomState(seed=0)
+    rstate = get_rstate()
     logzs = []
     for _ in range(10):
         sampler = dynesty.NestedSampler(loglike,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -60,6 +60,23 @@ def test_maxcall():
     sampler.run_nested(dlogz_init=1, maxcall=1000)
 
 
+def test_rstate_setting():
+    ndim = 2
+    rstate = np.random.RandomState(seed=0)
+    logzs = []
+    for _ in range(10):
+        sampler = dynesty.NestedSampler(loglike,
+                                        prior_transform,
+                                        ndim,
+                                        sample='rwalk',
+                                        nlive=nlive,
+                                        rstate=rstate)
+        sampler.run_nested(dlogz=1, maxcall=1)
+        logzs.append(sampler.results.logz[-1])
+    assert pytest.approx(logzs[0], rel=0.1) == np.array(logzs)
+
+
+
 def test_inf():
     # Test of logl that returns -inf
     ndim = 2


### PR DESCRIPTION
Hey @joshspeagle  and @segasai , 

Some devs and I at Monash Uni are having some trouble getting reproducible results with the same `rstate`. 
This PR includes a small test to demonstrate this issue, and hopefully check for it in the future. 

Here is also a script that plots N sampling results from the linear regression example, both using the same data and same sampling seed. 

```python
from __future__ import division, print_function
from six.moves import range
from functools import partial

import numpy as np

import matplotlib
from matplotlib import pyplot as plt
from matplotlib import rcParams

import dynesty
from dynesty import plotting as dyplot

TRUTHS = dict(
    m = -0.9594,
    b = 4.294,
    f = 0.534
)

def set_rcparams():
  rcParams.update({'xtick.major.pad': '7.0'})
  rcParams.update({'xtick.major.size': '7.5'})
  rcParams.update({'xtick.major.width': '1.5'})
  rcParams.update({'xtick.minor.pad': '7.0'})
  rcParams.update({'xtick.minor.size': '3.5'})
  rcParams.update({'xtick.minor.width': '1.0'})
  rcParams.update({'ytick.major.pad': '7.0'})
  rcParams.update({'ytick.major.size': '7.5'})
  rcParams.update({'ytick.major.width': '1.5'})
  rcParams.update({'ytick.minor.pad': '7.0'})
  rcParams.update({'ytick.minor.size': '3.5'})
  rcParams.update({'ytick.minor.width': '1.0'})
  rcParams.update({'font.size': 30})


def line_eq(m, x, b):
    return  m * x + b


def generate_data(theta, num = 50, generation_seed=0):
    np.random.seed(generation_seed)
    x = np.sort(10 * np.random.rand(num))
    yerr = 0.1 + 0.5 * np.random.rand(num)
    y_true = line_eq(theta['m'], x, theta['b'])
    y = y_true + np.abs(theta['f'] * y_true) * np.random.randn(num)
    y += yerr * np.random.randn(num)
    return x, y, yerr


# log-likelihood
def loglike_given_data(theta, x, y, yerr):
    m, b, lnf = theta
    model = line_eq(m, x, b)
    inv_sigma2 = 1.0 / (yerr**2 + model**2 * np.exp(2 * lnf))
    return -0.5 * (np.sum((y-model)**2 * inv_sigma2 - np.log(inv_sigma2)))

# prior transform
def prior_transform(utheta):
    um, ub, ulf = utheta
    m = 5.5 * um - 5.
    b = 10. * ub
    lnf = 11. * ulf - 10.
    return m, b, lnf


def run_sampler(x, y, yerr, rstate):
  loglike = partial(loglike_given_data, x=x, y=y, yerr=yerr)
  sampler = dynesty.NestedSampler(
      loglike, prior_transform, ndim=3,
      bound='multi', sample='rwalk', rstate=rstate
  )
  sampler.run_nested()
  return sampler.results


def repeat_sampler_run_with_fixed_seed(nruns=2, seed=0):
  x, y, yerr = generate_data(TRUTHS)
  results = []
  for i in range(nruns):
    print(f">>> Run {i}:")
    result = run_sampler(x, y, yerr, rstate=np.random.RandomState(seed=seed))
    results.append(result)
    print("------------")
  return results


def plot_results(results, fname="results.png"):
  set_rcparams()
  fig, axes = plt.subplots(4, 1, figsize=(12, 18))
  for i, r in enumerate(results):
      fig, axes = dyplot.runplot(r, color=f"C{i}", fig=(fig, axes))
  fig.tight_layout()
  fig.savefig(fname)


def main():
  results = repeat_sampler_run_with_fixed_seed()
  plot_results(results)


if __name__ == "__main__":
  main()
```

Note that the `runplot`s for the two runs look rather different: 

![results](https://user-images.githubusercontent.com/15642823/144604605-e0c76ca5-2110-44f2-a0e3-953f7f62d57a.png)


Is this a known feature? How can I set my rstate such that I can reproduce a run identically? 
