### PR TITLE
return random point if no MCMC steps accepted

### DIFF
--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -257,9 +257,9 @@ def generic_random_walk(u, loglstar, axes, scale, prior_transform,
         else:
             nreject += 1
     if naccept == 0:
-        # Technically we can find out the likelihood value
-        # stored somewhere
-        # But I'm currently recomputing it
+        # No MCMC steps were accepted. To avoid repeated nested
+        # samples return a random draw from the prior.
+        u = rstate.uniform(0, 1, n)
         v = prior_transform(u)
         logl = loglikelihood(v)
 


### PR DESCRIPTION
Hi @joshspeagle @segasai this PR fixes an issue in the `rwalk` proposal method.

Currently, if no steps are accepted the original point is returned. However, this point will almost always be accepted as there's only a 1 / nlive probability that it doesn't have a higher likelihood than the lowest likelihood live point (by definition).

Having repeated nested samples in the chain can easily lead to subtle biases and overly constrained ellipses.

The proposed fix is to just return a random point from the prior. This will almost certainly not be accepted but communicates to the sampler that no valid point was found.

(FWIW, we've been using a [version of this](https://git.ligo.org/lscsoft/bilby/-/blob/master/bilby/core/sampler/dynesty.py#L867-L870) in `Bilby` for a while.)