### PR TITLE
Do not compute n_effective when limit is infinite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Sampler.n_effective is no longer unnecessarily computed when sampling with
   an infinite limit on n_effective.
-- Setting n_effective for .run_nested() and .sample_initial() is deprecated.
+
+### Changed
+- Setting n_effective for Sampler.run_nested() and DynamicSampler.sample_initial(), and n_effective_init for DynamicSampler.run_nested(), are deprecated.
 
 ## [1.2.3] - 2022-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 ### Fixed
+- Sampler.n_effective is no longer unnecessarily computed when sampling with
+  an infinite limit on n_effective._
 
 ## [1.2.3] - 2022-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 ### Fixed
 - Sampler.n_effective is no longer unnecessarily computed when sampling with
-  an infinite limit on n_effective._
+  an infinite limit on n_effective.
+- Setting n_effective for .run_nested() and .sample_initial() is deprecated.
 
 ## [1.2.3] - 2022-06-02
 

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -722,9 +722,7 @@ class DynamicSampler:
             threshold set by `logl_max`. Default is no bound (`np.inf`).
 
         n_effective: int, optional
-            Target number of effective posterior samples. If the estimated
-            "effective sample size" (ESS) exceeds this number,
-            sampling will terminate. Default is no ESS (`np.inf`).
+            This option is deprecated and will be removed in a future release.
 
         live_points : list of 3 `~numpy.ndarray` each with shape (nlive, ndim)
             A set of live points used to initialize the nested sampling run.
@@ -787,6 +785,15 @@ class DynamicSampler:
             current evidence.
 
         """
+
+        # Check for deprecated options
+        if n_effective is not np.inf:
+            with warnings.catch_warnings():
+                warnings.filterwarnings("once")
+                warnings.warn(
+                    "The n_effective option to DynamicSampler.sample_initial "
+                    "is deprecated and will be removed in future releases",
+                    DeprecationWarning)
 
         # Initialize inputs.
         if maxcall is None:
@@ -1526,6 +1533,7 @@ class DynamicSampler:
             baseline run. If the estimated "effective sample size" (ESS)
             exceeds this number, sampling will terminate.
             Default is no ESS (`np.inf`).
+            This option is deprecated and will be removed in a future release.
 
         nlive_batch : int, optional
             The number of live points used when adding additional samples
@@ -1611,6 +1619,15 @@ class DynamicSampler:
             live points will result in biased results.**
 
         """
+
+        # Check for deprecated options
+        if n_effective_init is not np.inf:
+            with warnings.catch_warnings():
+                warnings.filterwarnings("once")
+                warnings.warn(
+                    "The n_effective_init option to DynamicSampler.run_nested "
+                    "is deprecated and will be removed in future releases",
+                    DeprecationWarning)
 
         # Initialize values.
         if maxcall is None:

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -843,6 +843,7 @@ class Sampler:
             Minimum number of effective posterior samples. If the estimated
             "effective sample size" (ESS) exceeds this number,
             sampling will terminate. Default is no ESS (`np.inf`).
+            This option is deprecated and will be removed in a future release.
 
         add_live : bool, optional
             Whether or not to add the remaining set of live points to
@@ -861,6 +862,15 @@ class Sampler:
             the live points internally. Default is *True*.
 
         """
+
+        # Check for deprecated options
+        if n_effective is not None:
+            with warnings.catch_warnings():
+                warnings.filterwarnings("once")
+                warnings.warn(
+                    "The n_effective option to Sampler.run_nested is "
+                    "deprecated and will be removed in future releases",
+                    DeprecationWarning)
 
         # Define our stopping criteria.
         if dlogz is None:

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -681,15 +681,16 @@ class Sampler:
             # Stopping criterion 5: the number of effective posterior
             # samples has been achieved.
             if (n_effective is not None) and not np.isposinf(n_effective):
-                if self.n_effective > n_effective:
+                current_n_effective = self.n_effective
+                if current_n_effective > n_effective:
                     if add_live:
                         self.add_final_live(print_progress=False)
-                        neff = self.n_effective
+
+                        # Recompute n_effective after adding live points
+                        current_n_effective = self.n_effective
                         self._remove_live_points()
                         self.added_live = False
-                    else:
-                        neff = self.n_effective
-                    if neff > n_effective:
+                    if current_n_effective > n_effective:
                         stop_iterations = True
 
             if stop_iterations:

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -680,7 +680,7 @@ class Sampler:
 
             # Stopping criterion 5: the number of effective posterior
             # samples has been achieved.
-            if n_effective is not None:
+            if (n_effective is not None) and not np.isposinf(n_effective):
                 if self.n_effective > n_effective:
                     if add_live:
                         self.add_final_live(print_progress=False)

--- a/tests/test_gau.py
+++ b/tests/test_gau.py
@@ -187,6 +187,27 @@ def test_generator():
     check_results_gau(res, g, rstate)
 
 
+def test_n_effective():
+    # Test that n_effective controls the sample size
+    rstate = get_rstate()
+    g = Gaussian()
+    sampler = dynesty.NestedSampler(g.loglikelihood,
+                                    g.prior_transform,
+                                    g.ndim,
+                                    nlive=nlive,
+                                    rstate=rstate)
+    target_n_effective = 2
+
+    current_n_effective = sampler.n_effective
+
+    for _ in sampler.sample(add_live=False,
+                            n_effective=target_n_effective):
+        previous_n_effective = current_n_effective
+        current_n_effective = sampler.n_effective
+
+    assert current_n_effective > target_n_effective > previous_n_effective
+
+
 # try all combinations excepte none/unif
 @pytest.mark.parametrize(
     "bound,sample",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -63,6 +63,33 @@ def test_maxcall():
     sampler.run_nested(dlogz_init=1, maxcall=1000, print_progress=printing)
 
 
+def test_n_effective_deprecation():
+    # test deprecation of n_effective and n_effective_init
+    ndim = 2
+    rstate = get_rstate()
+
+    sampler = dynesty.NestedSampler(loglike,
+                                    prior_transform,
+                                    ndim,
+                                    nlive=nlive,
+                                    rstate=rstate)
+    with pytest.deprecated_call():
+        sampler.run_nested(dlogz=1, maxcall=10, n_effective=10)
+
+    sampler = dynesty.DynamicNestedSampler(loglike,
+                                           prior_transform,
+                                           ndim,
+                                           nlive=nlive,
+                                           rstate=rstate)
+
+    sample_generator = sampler.sample_initial(n_effective=10)
+    with pytest.deprecated_call():
+        next(sample_generator)
+
+    with pytest.deprecated_call():
+        sampler.run_nested(dlogz_init=1, maxcall=10, n_effective_init=10)
+
+
 @pytest.mark.parametrize('dynamic,with_pool',
                          itertools.product([True, False], [True, False]))
 def test_pickle(dynamic, with_pool):


### PR DESCRIPTION
Currently the maximum number of effective samples `n_effective` in `Sampler.sample()` defaults to `np.inf`, implying no limit, yet `self.n_effective` is still computed (and then compared with `np.inf`), which takes time. The code already checks for `None`; this PR extends that check to also check that `n_effective` is not positive infinity before computing `n_effective`; this cuts the time spent in each call to `Sampler.sample()` by about half in the tests I've run.