### PR TITLE
Document requirements for test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,16 +29,7 @@ jobs:
       - name: Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install h5py
-          pip install pytest
-          pip install pylint
-          pip install pytest-cov
-          pip install coveralls
-          pip install sphinx
-          pip install sphinx-rtd-theme
-          pip install numpydoc
-          pip install tqdm
+          pip install -r requirements-dev.txt
           pip install .
       - name: Docs
         run: |

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,8 +1,14 @@
-
-The testing suite is executed using pytest with all the tests inside the tests/
+The testing suite is executed using pytest with all the tests inside the `tests/`
 folder
 
 A few notes
+
+### Requirements
+The test suite makes use of packages not included in `requirements.txt`. To install these additional packages, use
+
+```
+pip install -r requirements-dev.txt
+```
 
 ### Slow vs fast tests
 The majority of tests are designed to take together ~ 30 min of wall time, but a few tests take a long time. To exclude the slow tests you can run the pytest as
@@ -20,12 +26,13 @@ pytest --workers=10
 (if you have 10 CPUs). This way the test suite should finish in a few minutes.
 
 ### Random seeds
-By default the testing suite uses the same random seed for all the tests to ensure the consistency. It is occasionally useful to run with different seeds. For this you can set the environment variable DYNESTY_RANDOM_SEED to any integer value.
-If you are writing a new test you need to use the the get_rstate() function (from tests/utils.py)
+By default the testing suite uses the same random seed for all the tests to ensure the consistency. It is occasionally useful to run with different seeds. For this you can set the environment variable `DYNESTY_RANDOM_SEED` to any integer value.
+If you are writing a new test you need to use the the `get_rstate()` function (from `tests/utils.py`)
 
 
 ### Test printing
-By default most of the tests will not print any output. You can enable the printing of progress by setting the environment variable DYNESTY_TEST_PRINTING=1 and use -s flag of pytest
+By default most of the tests will not print any output. You can enable the printing of progress by setting the environment variable `DYNESTY_TEST_PRINTING=1` and use `-s` flag of pytest
 
-### jupyter notebooks tests
-To test that the jupyter notebooks run, you can run the tests/test_notebooks.py test
+### Jupyter notebooks tests
+To test that the Jupyter notebooks run, you can run the `tests/test_notebooks.py` test. These tests rely on dynesty 
+being installed in the Python environment referred to by the default `python3` Jupyter kernel.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,18 @@
 
 # Required for the test suite:
 pytest
-jupyter
+pytest-cov
+coveralls
+
+dill
 h5py
 tqdm
+
+jupyter
 ipyparallel
-dill
+
+pylint
+
+sphinx
+sphinx-rtd-theme
+numpydoc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+# Development requires all of the packages that installation requires
+-r requirements.txt
+
+# Required for the test suite:
+pytest
+jupyter
+h5py
+tqdm
+ipyparallel
+dill


### PR DESCRIPTION
While preparing #379, I hit a few errors where I didn't have the requisite packages for the test suite installed. This PR will document these requirements in `requirements-dev.txt`, and mention this in the `TESTING.md` documentation. It then adjusts the GitHub Actions workflow to use this file rather than re-listing the requirements manually in the workflow definition.