### PR TITLE
Doubling steps with slice sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Setting n_effective for Sampler.run_nested() and DynamicSampler.sample_initial(), and n_effective_init for DynamicSampler.run_nested(), are deprecated.
-- The slice sampling can now switch to doubling algorithm, if at any point of the sampling the interval was expanded more than 1000 times. It should help slice/rslice sampling of difficult posteriors.
+- The slice sampling can now switch to doubling interval expansion algorithm from Neal(2003), if at any point of the sampling the interval was expanded more than 1000 times. It should help slice/rslice sampling of difficult posteriors.
 
 ## [1.2.3] - 2022-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Setting n_effective for Sampler.run_nested() and DynamicSampler.sample_initial(), and n_effective_init for DynamicSampler.run_nested(), are deprecated.
+- The slice sampling can now switch to doubling algorithm, if at any point of the sampling the interval was expanded more than 1000 times. It should help slice/rslice sampling of difficult posteriors.
 
 ## [1.2.3] - 2022-06-02
 

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -192,6 +192,8 @@ class SuperSampler(Sampler):
         # Remember I can't apply the rule that scale < cube diagonal
         # because scale is multiplied by axes
         self.scale = self.scale * mult
+        if blob['expansion_warning_set']:
+            self.kwargs['slice_doubling'] = True
 
     def update_hslice(self, blob):
         """Update the Hamiltonian slice proposal scale based

--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -559,6 +559,8 @@ def sample_slice(args):
             nexpand += nexpand1
             ncontract += ncontract1
             if expansion_warning:
+                # if we expanded the interval by more than
+                # the threshold we set the warning and enable doubling
                 expansion_warning_set = True
                 doubling = True
 

--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -286,7 +286,7 @@ def propose_ball_point(u,
 
     # draw random point for non clustering parameters
     # we only need to generate them once
-    u_non_cluster = rstate.uniform(0, 1, n - n_cluster)
+    u_non_cluster = rstate.random(n - n_cluster)
     u_prop = np.zeros(n)
     u_prop[n_cluster:] = u_non_cluster
 
@@ -372,7 +372,7 @@ def generic_slice_step(u, direction, nonperiodic, loglstar, loglikelihood,
     nc, nexpand, ncontract = 0, 0, 0
     nexpand_threshold = 1000  # Threshold for warning the user
     n = len(u)
-    rand0 = rstate.uniform()  # initial scale/offset
+    rand0 = rstate.random()  # initial scale/offset
     dirlen = linalg.norm(direction)
     maxlen = np.sqrt(n) / 2.
     # maximum initial interval length (the diagonal of the cube)
@@ -423,7 +423,7 @@ def generic_slice_step(u, direction, nonperiodic, loglstar, loglikelihood,
         # "Stepping out" the left and right bounds.
         K = 1
         while (logl_l > loglstar or logl_r > loglstar):
-            V = rstate.uniform()
+            V = rstate.random()
             if V < 0.5:
                 nstep_l -= (nstep_r - nstep_l)
                 logl_l = F(nstep_l)[1]
@@ -445,7 +445,7 @@ def generic_slice_step(u, direction, nonperiodic, loglstar, loglikelihood,
         nstep_hat = nstep_r - nstep_l
 
         # Propose new position.
-        nstep_prop = nstep_l + rstate.uniform() * nstep_hat  # scale from left
+        nstep_prop = nstep_l + rstate.random() * nstep_hat  # scale from left
         u_prop, logl_prop = F(nstep_prop)
         ncontract += 1
 
@@ -1099,7 +1099,7 @@ def sample_hslice(args):
             # Define chord.
             u_l, u_m, u_r = nodes_l[idx], nodes_m[idx], nodes_r[idx]
             u_hat = u_r - u_l
-            rprop = rstate.uniform()
+            rprop = rstate.random()
             u_prop = u_l + rprop * u_hat  # scale from left
             if unitcheck(u_prop, nonperiodic):
                 v_prop = prior_transform(np.asarray(u_prop))

--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -316,7 +316,7 @@ def propose_ball_point(u,
 def _slice_doubling_accept(x1, F, loglstar, L, R, fL, fR):
     """
     Acceptance test of slice sampling when doubling mode is used.
-    This is an exact implementation of algo 6 of neal 2003
+    This is an exact implementation of algorithm 6 of Neal 2003
     here w=1 and x0=0 as we are working in the
     coordinate system of F(A) = f(x0+A*w)
 
@@ -579,8 +579,8 @@ def sample_slice(args):
                 # the threshold we set the warning and enable doubling
                 expansion_warning_set = True
                 doubling = True
-                warnings.warn('Enabling doubling strategy of slice'
-                              'sampling from Neal2003')
+                warnings.warn('Enabling doubling strategy of slice '
+                              'sampling from Neal(2003)')
     blob = {
         'nexpand': nexpand,
         'ncontract': ncontract,
@@ -680,8 +680,8 @@ def sample_rslice(args):
         if expansion_warning and not doubling:
             doubling = True
             expansion_warning_set = True
-            warnings.warn('Enabling doubling strategy of slice'
-                          'sampling from Neal2003')
+            warnings.warn('Enabling doubling strategy of slice '
+                          'sampling from Neal(2003)')
 
     blob = {
         'nexpand': nexpand,

--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -314,7 +314,7 @@ def propose_ball_point(u,
 
 
 def generic_slice_step(u, direction, nonperiodic, loglstar, loglikelihood,
-                       prior_transform, rstate):
+                       prior_transform, doubling, rstate):
     """
     Do a slice generic slice sampling step along a specified dimension
 
@@ -365,20 +365,64 @@ def generic_slice_step(u, direction, nonperiodic, loglstar, loglikelihood,
     logl_l = F(nstep_l)[1]
     logl_r = F(nstep_r)[1]
 
-    # "Stepping out" the left and right bounds.
-    while logl_l > loglstar:
-        nstep_l -= 1
-        logl_l = F(nstep_l)[1]
-        nexpand += 1
-    while logl_r > loglstar:
-        nstep_r += 1
-        logl_r = F(nstep_r)[1]
-        nexpand += 1
-    if nexpand > nexpand_threshold:
-        warnings.warn(
-            str.format(
-                'The slice sample interval was expanded more than {0} times',
-                nexpand_threshold))
+    if not doubling:
+        # "Stepping out" the left and right bounds.
+        while logl_l > loglstar:
+            nstep_l -= 1
+            logl_l = F(nstep_l)[1]
+            nexpand += 1
+        while logl_r > loglstar:
+            nstep_r += 1
+            logl_r = F(nstep_r)[1]
+            nexpand += 1
+        if nexpand > nexpand_threshold:
+            warnings.warn(
+                str.format(
+                    'The slice sample interval was expanded more '
+                    'than {0} times', nexpand_threshold))
+
+        def accept(x):
+            return True
+    else:
+        # "Stepping out" the left and right bounds.
+        K = 1
+        while (logl_l > loglstar or logl_r > loglstar):
+            V = rstate.uniform()
+            if V < 0.5:
+                nstep_l -= (nstep_r - nstep_l)
+                logl_l = F(nstep_l)[1]
+            else:
+                nstep_r += (nstep_r - nstep_l)
+                logl_r = F(nstep_r)[1]
+            nexpand += K
+            K *= 2
+        L = nstep_l
+        R = nstep_r
+
+        def accept(x1):
+            # exact implementation of algo 6 of neal 2003
+            # here w=1 and x0=0 as we are working in the
+            # coordinate system of F(A) = f(x0+A*w)
+            lhat, rhat = L, R
+            f_lhat = F(lhat)[1]
+            f_rhat = F(rhat)[1]
+            D = False
+            while rhat - lhat > 1.1:
+                # Define slice and window.
+                M = (lhat + rhat) / 2.
+                # Propose new position.
+                if (M > 0 and x1 >= M) or (M <= 0 and x1 < M):
+                    D = True
+                if x1 < M:
+                    rhat = M
+                    f_rhat = F(rhat)[1]
+                else:
+                    lhat = M
+                    f_lhat = F(lhat)[1]
+                if D and loglstar >= f_lhat and loglstar >= f_rhat:
+                    return False
+            return True
+
     # Sample within limits. If the sample is not valid, shrink
     # the limits until we hit the `loglstar` bound.
 
@@ -392,135 +436,7 @@ def generic_slice_step(u, direction, nonperiodic, loglstar, loglikelihood,
         ncontract += 1
 
         # If we succeed, move to the new position.
-        if logl_prop > loglstar:
-            break
-        # If we fail, check if the new point is to the left/right of
-        # our original point along our proposal axis and update
-        # the bounds accordingly.
-        else:
-            if nstep_prop < 0:
-                nstep_l = nstep_prop
-            elif nstep_prop > 0:  # right
-                nstep_r = nstep_prop
-            else:
-                # If `nstep_prop = 0` something has gone horribly wrong.
-                raise RuntimeError("Slice sampler has failed to find "
-                                   "a valid point. Some useful "
-                                   "output quantities:\n"
-                                   "u: {0}\n"
-                                   "nstep_left: {1}\n"
-                                   "nstep_right: {2}\n"
-                                   "nstep_hat: {3}\n"
-                                   "u_prop: {4}\n"
-                                   "loglstar: {5}\n"
-                                   "logl_prop: {6}\n"
-                                   "direction: {7}\n".format(
-                                       u, nstep_l, nstep_r, nstep_hat, u_prop,
-                                       loglstar, logl_prop, direction))
-    v_prop = prior_transform(u_prop)
-    return u_prop, v_prop, logl_prop, nc, nexpand, ncontract
-
-
-def generic_slice_doubling_step(u, direction, nonperiodic, loglstar,
-                                loglikelihood, prior_transform, rstate):
-    """
-    Do a slice generic slice sampling step along a specified dimension using
-    the doubling algorithm from Neal 2003 (algo number 4)
-
-    Arguments
-    u: ndarray (ndim sized)
-        Starting point in unit cube coordinates
-        It MUST satisfy the logl>loglstar criterion
-    direction: ndarray (ndim sized)
-        Step direction vector
-    nonperiodic: ndarray(bool)
-        mask for nonperiodic variables
-    loglstar: float
-        the critical value of logl, so that new logl must be >loglstar
-    loglikelihood: function
-    prior_transform: function
-    rstate: random state
-    """
-    nc, nexpand, ncontract = 0, 0, 0
-    n = len(u)
-    rand0 = rstate.uniform()  # initial scale/offset
-    dirlen = linalg.norm(direction)
-    maxlen = np.sqrt(n) / 2.
-    # maximum initial interval length (the diagonal of the cube)
-    if dirlen > maxlen:
-        # I stopped giving warnings, as it was too noisy
-        dirnorm = dirlen / maxlen
-    else:
-        dirnorm = 1
-    direction = direction / dirnorm
-
-    #  The function that evaluates the logl at the location of
-    # u0 + x*direction0
-    def F(x):
-        nonlocal nc
-        u_new = u + x * direction
-        if unitcheck(u_new, nonperiodic):
-            logl = loglikelihood(prior_transform(u_new))
-        else:
-            logl = -np.inf
-        nc += 1
-        return u_new, logl
-
-    # asymmetric step size on the left/right (see Neal 2003)
-    nstep_l = -rand0
-    nstep_r = (1 - rand0)
-    logl_l = F(nstep_l)[1]
-    logl_r = F(nstep_r)[1]
-
-    # "Stepping out" the left and right bounds.
-    while (logl_l > loglstar or logl_r > loglstar):
-        K = 1
-        V = rstate.uniform()
-        if V < 0.5:
-            nstep_l -= (nstep_r - nstep_l)
-            logl_l = F(nstep_l)[1]
-        else:
-            nstep_r += (nstep_r - nstep_l)
-            logl_r = F(nstep_r)[1]
-        nexpand += K
-        K *= 2
-
-    L = nstep_l
-    R = nstep_r
-
-    def accept(x1):
-        # fig6 of neal 2003
-        lhat, rhat = L, R
-        f_lhat = F(lhat)[1]
-        f_rhat = F(rhat)[1]
-        D = False
-        while rhat - lhat > 1.1:
-            # Define slice and window.
-            M = (lhat + rhat) / 2.
-            # Propose new position.
-            if (M > 0 and x1 >= M) or (M <= 0 and x1 < M):
-                D = True
-            if x1 < M:
-                rhat = M
-                f_rhat = F(rhat)[1]
-            else:
-                lhat = M
-                f_lhat = F(lhat)[1]
-            if D and loglstar >= f_lhat and loglstar >= f_rhat:
-                return False
-        return True
-
-    while True:
-        # Define slice and window.
-        nstep_hat = nstep_r - nstep_l
-
-        # Propose new position.
-        nstep_prop = nstep_l + rstate.uniform() * nstep_hat  # scale from left
-        u_prop, logl_prop = F(nstep_prop)
-        ncontract += 1
-
-        # If we succeed, move to the new position.
-        if logl_prop > loglstar and accept(nstep_prop, L, R):
+        if logl_prop > loglstar and accept(nstep_prop):
             break
         # If we fail, check if the new point is to the left/right of
         # our original point along our proposal axis and update
@@ -635,7 +551,7 @@ def sample_slice(args):
             (u_prop, v_prop, logl_prop, nc1, nexpand1,
              ncontract1) = generic_slice_step(u, axis, nonperiodic, loglstar,
                                               loglikelihood, prior_transform,
-                                              rstate)
+                                              False, rstate)
             u = u_prop
             nc += nc1
             nexpand += nexpand1
@@ -725,7 +641,7 @@ def sample_rslice(args):
         (u_prop, v_prop, logl_prop, nc1, nexpand1,
          ncontract1) = generic_slice_step(u, direction, nonperiodic, loglstar,
                                           loglikelihood, prior_transform,
-                                          rstate)
+                                          False, rstate)
         u = u_prop
         nc += nc1
         nexpand += nexpand1

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -80,6 +80,7 @@ def doit(model='diamond',
         raise Exception('unknown')
     func = {
         'rslice': ds.sample_rslice,
+        'hslice': ds.sample_hslice,
         'slice': ds.sample_slice,
         'rwalk': ds.sample_rwalk
     }[sample]

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,0 +1,136 @@
+import numpy as np
+import dynesty.sampling as ds
+from utils import get_rstate
+
+
+def diamond_logl(X):
+    x, y = X
+    x1 = np.abs(x - 0.5)
+    y1 = np.abs(y - 0.5)
+    if X.min() < 0 or X.max() > 1:
+        return -np.inf
+    D2 = (x1 - 0.5)**2 + (y1 - 0.5)**2
+    if D2 > 0.5**2:
+        return (D2 - 0.5**2) / (0.5 - 0.5**2)
+    else:
+        return -np.inf
+
+
+def checker_logl(X):
+    mult = 16 * 2 * np.pi
+    x, y = X
+    logl = np.sin(x * mult) * np.sin(y * mult)
+    if X.min() < 0 or X.max() > 1:
+        return -np.inf
+    return logl
+
+
+def pdf_test(func, curx, nbins=100, thresh=6):
+    hh, loc = np.histogram(curx, range=[0, 1], bins=nbins)
+    xloc = loc[:-1] + .5 * np.diff(loc)
+    pdf = hh / (loc[1] - loc[0]) / len(curx)
+    epdf = np.maximum(hh, 1)**.5 / (loc[1] - loc[0]) / len(curx)
+
+    rat = np.abs(func(xloc) - pdf) / epdf
+    assert rat.max() < thresh
+
+
+def diamond_test(X):
+
+    def func(x):
+        return (1 - 2 * np.sqrt(np.abs(x - 0.5) -
+                                (x - 0.5)**2)) / (1 - np.pi / 4)
+
+    for i in range(2):
+        curx = X[:, i]
+        pdf_test(func, curx)
+
+
+def checker_test(X, thresh=6):
+
+    def func(x):
+        return 1
+
+    for i in range(2):
+        curx = X[:, i]
+        pdf_test(func, curx, thresh=thresh)
+
+
+def doit(model='diamond',
+         sample='rslice',
+         scale=1,
+         rstate=None,
+         niter=100_000,
+         doubling=False,
+         slices=1,
+         walks=1):
+    loglstar = 0.
+    u = np.r_[.5, .5]
+    kwargs = {'slices': slices, 'walks': walks, 'slice_doubling': doubling}
+    if rstate is not None:
+        rng = rstate
+    else:
+        rng = np.random.default_rng(1)
+    us = np.zeros((niter, 2))
+    if model == 'diamond':
+        curlogl = diamond_logl
+    elif model == 'checkerboard':
+        curlogl = checker_logl
+    else:
+        raise Exception('unknown')
+    func = {
+        'rslice': ds.sample_rslice,
+        'slice': ds.sample_slice,
+        'rwalk': ds.sample_rwalk
+    }[sample]
+
+    for i in range(niter):
+        seed = rng.integers(1e9)
+        args = (u, loglstar, np.eye(2), scale, lambda x: x, curlogl, seed,
+                kwargs)
+        u = func(args)[0]
+        us[i] = u
+    return us
+
+
+def test_all():
+    rs = get_rstate()
+    us = doit(model='diamond',
+              sample='rwalk',
+              scale=.3,
+              rstate=rs,
+              niter=100_000,
+              walks=10)
+    diamond_test(us)
+
+    us = doit(model='diamond',
+              sample='rslice',
+              scale=.3,
+              rstate=rs,
+              slices=10,
+              niter=100_000)
+    diamond_test(us)
+
+    us = doit(model='diamond',
+              sample='rslice',
+              scale=.3,
+              rstate=rs,
+              niter=100_000,
+              doubling=True)
+    diamond_test(us)
+
+    us = doit(model='checkerboard',
+              sample='rslice',
+              scale=.001,
+              rstate=rs,
+              niter=100_000,
+              doubling=True)
+    checker_test(us)
+
+    us = doit(model='diamond',
+              sample='slice',
+              scale=.3,
+              rstate=rs,
+              slices=1,
+              niter=100_000)
+    diamond_test(us)


### PR DESCRIPTION
This is the PR and proposal to add a slice sampling doubling scheme from Neal 2003 (scheme number 4). 

The reason for this is this test for example. 

```python
from __future__ import (print_function, division)
import numpy as np
import dynesty

nlive = 1000
printing = True  # get_printing()


def loglike(x):
    x1 = (x * 1e7)
    x2 = x1.astype(int)

    rng = np.random.default_rng(x2)

    logl = rng.uniform() * 100 + 1e-9 * (x2 - x1).sum()
    return logl


def prior_transform(x):
    return x


def test_pathology():
    ndim = 4
    rstate = np.random.default_rng(56432)
    SAMPLER = dynesty.DynamicNestedSampler
    kw = dict()
    sampler = SAMPLER(loglike,
                      prior_transform,
                      ndim,
                      nlive=nlive,
                      bound='multi',
                      sample='rslice',
                      rstate=rstate)
    sampler.run_nested(print_progress=printing, **kw)


test_pathology()
```

When one runs it the code hits the '>10000' expansions and then proceeds extremely slowly. 
The reason is that this rugged (random) likelihood gets very small 'scale' parameter when sampling, and occasionally when the ellipsoids get much smaller one can end up in the situation when the bounding ellipsoid and scale parameter are equally small -- this leads to the extremely high number of expansions in the slice algorithm. And since the tuning of the scale parameter is only done by a factor of two no more, it takes a long while for the algorithm to get back to normal speed. 

The proposed patch just implements the doubling scheme for slice sampling but doesn't enable it yet.

The possible option to enabling it are
* always enable it
* create an option to enable it
* enable it as soon as we hit a 'nexpand> THRESHOLD' once.

I'm inclined to chose the last option, or maybe the first one. The only reason I'm not sure about the last option is additional complexity in tracking the event that we've hit the expansion threshold.

For the example code given above if I don't do anything, the code ~ hangs after a minute of running taking 2 minutes to just do one iteration:
8008it [00:30, 340.39it/s, batch: 0 | bound: 17 | nc: 124 | ncall: 225942 | eff(%):  3.529 | loglstar:   -inf < 99.959 <    inf8009it [02:58,  1.81s/it, batch: 0 | bound: 18 | nc: 3330173 | ncall: 3556115 | eff(%):  0.225 | loglstar:   -inf < 99.959 <    inf | logz: 95.337 +/-  0.060 | dlogz:  0.035 >  0.010]/home/skoposov/pyenv38/lib/python3.8/site-packages/dynesty/sampling.py:378: UserWarning: The slice sample interval was expanded more than 10000 times
  warnings.warn(
The total run takes ~ 7 min. 
While with the change, the sampling finishes in 56 seconds. 

While comparing the number of calls/iteration (before the hanging) I can also see that the doubling scheme requires more function calls ~ 1.5 times more in this case, which would support not making this a default option.