### PR TITLE
improve the rwalk behaviour for difficult cases.

### DIFF
--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -219,11 +219,10 @@ def generic_random_walk(u, loglstar, axes, scale, prior_transform,
     ncall = 0
     # Total number of Likelihood calls (proposals evaluated)
 
+    nell = 0
+
     # Here we loop for exactly walks iterations.
     while ncall < walks:
-
-        # This proposes a new point within the ellipsoid
-        # This also potentially modifies the scale
         u_prop, fail = propose_ball_point(u,
                                           scale,
                                           axes,
@@ -233,11 +232,11 @@ def generic_random_walk(u, loglstar, axes, scale, prior_transform,
                                           periodic=periodic,
                                           reflective=reflective,
                                           nonbounded=nonbounded)
-        # If generation of points within an ellipsoid was
-        # highly inefficient we adjust the scale
         if fail:
+            # if the point is not in the cube even, we continue looping
+            # we don't consider it as a step
+            nell += 1
             nreject += 1
-            ncall += 1
             continue
 
         # Check proposed point.
@@ -252,6 +251,9 @@ def generic_random_walk(u, loglstar, axes, scale, prior_transform,
             naccept += 1
         else:
             nreject += 1
+    if nell > 10000 * walks:
+        warnings.warn("The generation of proposal points for random walk "
+                      "is highly inefficient")
     if naccept == 0:
         # Technically we can find out the likelihood value
         # stored somewhere


### PR DESCRIPTION
This is a small but useful improvement. 
When doing random walk sampling the walking consists of two parts.
* Generating a point in a random ball/ellipse around the current point.
* Testing if it is accepted based on logl criteria

These steps are repeated 'walks' times. 
Sometimes even the first step generation of a point can fail, because say the ellipsoid is longer than the cube and a generated point is outside. Now I do not consider that as a 'walk'. I only consider walk attempts that are within the cube and that get a function evaluation. 
That should make things more stable and reduce situations when the none of walking steps are accepted (i.e. #354 )