### PR TITLE
Proposal update change 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   an infinite limit on n_effective.
 
 ### Changed
-- Setting n_effective for Sampler.run_nested() and DynamicSampler.sample_initial(), and n_effective_init for DynamicSampler.run_nested(), are deprecated.
-- The slice sampling can now switch to doubling interval expansion algorithm from Neal(2003), if at any point of the sampling the interval was expanded more than 1000 times. It should help slice/rslice sampling of difficult posteriors.
+- Setting n_effective for Sampler.run_nested() and DynamicSampler.sample_initial(), and n_effective_init for DynamicSampler.run_nested(), are deprecated ( #379 ; by @edbennett )
+- The slice sampling can now switch to doubling interval expansion algorithm from Neal(2003), if at any point of the sampling the interval was expanded more than 1000 times. It should help slice/rslice sampling of difficult posteriors ( #382; by @segasai )
+- The .update_proposal() function that updates the states of samplers
+now has an additional keyword which allows to either just accumulate the statistics from repeated function calls or actual update of the proposal. This was needed to not loose information when queue_size>1 (#385; by @segasai )
 
 ## [1.2.3] - 2022-06-02
 

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -146,11 +146,11 @@ class SuperSampler(Sampler):
     def propose_live(self, *args):
         pass
 
-    def update_unif(self, blob, update):
+    def update_unif(self, blob, update=True):
         """Filler function."""
         pass
 
-    def update_rwalk(self, blob, update):
+    def update_rwalk(self, blob, update=True):
         """Update the random walk proposal scale based on the current
         number of accepted/rejected steps.
         For rwalk the scale is important because it
@@ -158,6 +158,8 @@ class SuperSampler(Sampler):
         I.e. if scale is too large, the proposal efficiency will be very low
         so it's likely that we'll only do one random walk step at the time,
         thus producing very correlated chain.
+        The keyword update determines if we are just accumulating the number
+        of steps or actually adjusting the scale
         """
         self.scale = blob['scale']
         hist = self.rwalk_history
@@ -183,12 +185,14 @@ class SuperSampler(Sampler):
         hist['naccept'] = 0
         hist['nreject'] = 0
 
-    def update_slice(self, blob, update):
+    def update_slice(self, blob, update=True):
         """Update the slice proposal scale based on the relative
         size of the slices compared to our initial guess.
         For slice sampling the scale is only 'advisory' in the sense that
         the right scale will just speed up sampling as we'll have to expand
         or contract less. It won't affect the quality of the samples much.
+        The keyword update determines if we are just accumulating the number
+        of steps or actually adjusting the scale
         """
         # see https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4063214/
         # also 2002.06212
@@ -213,9 +217,12 @@ class SuperSampler(Sampler):
         hist['nexpand'] = 0
         hist['ncontract'] = 0
 
-    def update_hslice(self, blob, update):
+    def update_hslice(self, blob, update=True):
         """Update the Hamiltonian slice proposal scale based
-        on the relative amount of time spent moving vs reflecting."""
+        on the relative amount of time spent moving vs reflecting.
+        The keyword update determines if we are just accumulating the number
+        of steps or actually adjusting the scale
+        """
         hist = self.hslice_history
         hist['nmove'] += blob['nmove']
         hist['nreflect'] += blob['nreflect']

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -131,11 +131,14 @@ class SuperSampler(Sampler):
         self.walks = max(2, self.kwargs.get('walks', 25))
         self.facc = self.kwargs.get('facc', 0.5)
         self.facc = min(1., max(1. / self.walks, self.facc))
+        self.rwalk_history = {'naccept': 0, 'nreject': 0}
 
         # Initialize slice parameters.
         self.slices = self.kwargs.get('slices', 5)
         self.fmove = self.kwargs.get('fmove', 0.9)
         self.max_move = self.kwargs.get('max_move', 100)
+        self.slice_history = {'ncontract': 0, 'nexpand': 0}
+        self.hslice_history = {'nmove': 0, 'nreflect': 0, 'ncontract': 0}
 
     def propose_unif(self, *args):
         pass
@@ -143,11 +146,11 @@ class SuperSampler(Sampler):
     def propose_live(self, *args):
         pass
 
-    def update_unif(self, blob):
+    def update_unif(self, blob, update):
         """Filler function."""
         pass
 
-    def update_rwalk(self, blob):
+    def update_rwalk(self, blob, update):
         """Update the random walk proposal scale based on the current
         number of accepted/rejected steps.
         For rwalk the scale is important because it
@@ -157,7 +160,12 @@ class SuperSampler(Sampler):
         thus producing very correlated chain.
         """
         self.scale = blob['scale']
-        accept, reject = blob['accept'], blob['reject']
+        hist = self.rwalk_history
+        hist['naccept'] += blob['accept']
+        hist['nreject'] += blob['reject']
+        if not update:
+            return
+        accept, reject = hist['naccept'], hist['nreject']
         facc = (1. * accept) / (accept + reject)
         # Here we are now trying to solve the Eqn
         # f0 = F(s) where F is the function
@@ -172,8 +180,10 @@ class SuperSampler(Sampler):
         # See also Robbins-Munro recursion which we don't follow
         # here because our coefficients a_k do not obey \sum a_k^2 = \infty
         self.scale *= math.exp((facc - self.facc) / self.ncdim / self.facc)
+        hist['naccept'] = 0
+        hist['nreject'] = 0
 
-    def update_slice(self, blob):
+    def update_slice(self, blob, update):
         """Update the slice proposal scale based on the relative
         size of the slices compared to our initial guess.
         For slice sampling the scale is only 'advisory' in the sense that
@@ -184,7 +194,15 @@ class SuperSampler(Sampler):
         # also 2002.06212
         # https://www.tandfonline.com/doi/full/10.1080/10618600.2013.791193
         # and https://github.com/joshspeagle/dynesty/issues/260
-        nexpand, ncontract = max(blob['nexpand'], 1), blob['ncontract']
+        hist = self.slice_history
+
+        hist['nexpand'] += blob['nexpand']
+        hist['ncontract'] += blob['ncontract']
+        if blob['expansion_warning_set']:
+            self.kwargs['slice_doubling'] = True
+        if not update:
+            return
+        nexpand, ncontract = max(hist['nexpand'], 1), hist['ncontract']
         mult = (nexpand * 2. / (nexpand + ncontract))
         # avoid drastic updates to the scale factor limiting to factor
         # of two
@@ -192,20 +210,28 @@ class SuperSampler(Sampler):
         # Remember I can't apply the rule that scale < cube diagonal
         # because scale is multiplied by axes
         self.scale = self.scale * mult
-        if blob['expansion_warning_set']:
-            self.kwargs['slice_doubling'] = True
+        hist['nexpand'] = 0
+        hist['ncontract'] = 0
 
-    def update_hslice(self, blob):
+    def update_hslice(self, blob, update):
         """Update the Hamiltonian slice proposal scale based
         on the relative amount of time spent moving vs reflecting."""
-
-        nmove, nreflect = blob['nmove'], blob['nreflect']
-        ncontract = blob.get('ncontract', 0)
+        hist = self.hslice_history
+        hist['nmove'] += blob['nmove']
+        hist['nreflect'] += blob['nreflect']
+        hist['ncontract'] += blob.get('ncontract', 0)
+        if not update:
+            return
+        nmove, nreflect = hist['nmove'], hist['nreflect']
+        ncontract = hist['ncontract']
         fmove = (1. * nmove) / (nmove + nreflect + ncontract + 2)
         norm = max(self.fmove, 1. - self.fmove)
         self.scale *= math.exp((fmove - self.fmove) / norm)
+        hist['nmove'] = 0
+        hist['nreflect'] = 0
+        hist['ncontract'] = 0
 
-    def update_user(self, blob):
+    def update_user(self, blob, update):
         """Update the scale based on the user-defined update function."""
 
         if callable(self.custom_update):

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -238,11 +238,11 @@ class SuperSampler(Sampler):
         hist['nreflect'] = 0
         hist['ncontract'] = 0
 
-    def update_user(self, blob, update):
+    def update_user(self, blob, update=True):
         """Update the scale based on the user-defined update function."""
 
         if callable(self.custom_update):
-            self.scale = self.custom_update(blob, self.scale)
+            self.scale = self.custom_update(blob, self.scale, update=update)
 
 
 class UnitCubeSampler(SuperSampler):

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -139,7 +139,7 @@ class Sampler:
     def evolve_point(self, *args):
         raise RuntimeError('Should be overriden')
 
-    def update_proposal(self, *args):
+    def update_proposal(self, *args, **kwargs):
         raise RuntimeError('Should be overriden')
 
     def update(self):
@@ -361,10 +361,12 @@ class Sampler:
             ucheck = ncall >= self.update_interval * (1 + nupdate)
             bcheck = self._beyond_unit_bound(loglstar)
 
-            # If our queue is empty, update any tuning parameters associated
-            # with our proposal (sampling) method.
             if blob is not None and bcheck:
-                self.update_proposal(blob, self.nqueue <= 0)
+                # If our queue is empty, update any tuning parameters associated
+                # with our proposal (sampling) method.
+                # If it's not empty we are just accumulating the
+                # the history of evaluations
+                self.update_proposal(blob, update=self.nqueue <= 0)
 
             # If we satisfy the log-likelihood constraint, we're done!
             if logl > loglstar:

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -363,8 +363,8 @@ class Sampler:
 
             # If our queue is empty, update any tuning parameters associated
             # with our proposal (sampling) method.
-            if blob is not None and self.nqueue <= 0 and bcheck:
-                self.update_proposal(blob)
+            if blob is not None and bcheck:
+                self.update_proposal(blob, self.nqueue <= 0)
 
             # If we satisfy the log-likelihood constraint, we're done!
             if logl > loglstar:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -72,6 +72,24 @@ def test_pool_dynamic():
                 5. * sampler.results.logzerr[-1])
 
 
+@pytest.mark.parametrize('sample', ['slice', 'rwalk', 'rslice'])
+def test_pool_samplers(sample):
+    # this is to test how the samplers are dealing with queue_size>1
+    rstate = get_rstate()
+    with mp.Pool(2) as pool:
+        sampler = dynesty.NestedSampler(loglike_gau,
+                                        prior_transform_gau,
+                                        ndim,
+                                        nlive=nlive,
+                                        sample=sample,
+                                        pool=pool,
+                                        queue_size=10,
+                                        rstate=rstate)
+        sampler.run_nested(print_progress=printing)
+        assert (abs(LOGZ_TRUTH_GAU - sampler.results.logz[-1]) <
+                5. * sampler.results.logzerr[-1])
+
+
 POOL_KW = ['prior_transform', 'loglikelihood', 'propose_point', 'update_bound']
 
 


### PR DESCRIPTION
This is a change trying to address how tuning of proposal distributions is done. 
Previously only 'blob' returned from one every 'queue_size' was used to adjust the tuning params. 
With this change the update_PROPOSAL() are called every time to mostly accumulate statistics on number of acceptances and rejects and the actual update will happen still every queue_size. 

The advantages are 
* the scale adjustment can become much less noisy. I.e. if some parts of the posterior may require smaller scale. Currently that info may be missed, because only one of every queue_size results is analyzed 
* We can react by switching to doubling scheme for slice sampling even if just a single likelihood evaluation had an issue 

Disadvantages: 
* change in the update_() interface
* a little bit more CPU overhead
* additional attributes in the sampler 

I think the advantages are worth it, but I think some refactoring may be warranted, like grouping the samplers in a separate classes, so they can keep the information there