### PR TITLE
Bug with maxiter/maxcall and dynamic sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is a major release with as several significant improvements. One is the imp
 ### Fixed
 - Sampler.n_effective is no longer unnecessarily computed when sampling with
   an infinite limit on n_effective. ( #379 ; by @edbennett )
+- In rare occasions, dynamic nested samplng fits with maxiter set could have failed with 'list index out of range' errors. That was addressed ( #392 ; by @segasai )
 
 ### Changed
 - Setting n_effective for Sampler.run_nested() and DynamicSampler.sample_initial(), and n_effective_init for DynamicSampler.run_nested(), are deprecated ( #379 ; by @edbennett )

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -1383,14 +1383,21 @@ class DynamicSampler:
                                       boundidx=results.boundidx,
                                       bounditer=results.bounditer,
                                       eff=self.eff)
-        if iterated_batch:
-            if results.loglstar < logl_max and np.isfinite(
-                    logl_max) and maxiter_left > 0 and maxcall_left > 0:
-                warnings.warn('Warning. The maximum likelihood not reached '
-                              'in the batch. '
-                              'You may not have enough livepoints')
-            self.internal_state = DynamicSamplerStatesEnum.INBATCHADDLIVE
+        if iterated_batch and results.loglstar < logl_max and np.isfinite(
+                logl_max) and maxiter_left > 0 and maxcall_left > 0:
+            warnings.warn('Warning. The maximum likelihood not reached '
+                          'in the batch. '
+                          'You may not have enough livepoints')
+        self.internal_state = DynamicSamplerStatesEnum.INBATCHADDLIVE
 
+        if not iterated_batch and len(batch_sampler.saved_run.D['logl']) == 0:
+            # This is a special case *if* we only sampled the initial livepoints
+            # but never did sample after
+            batch_sampler.saved_run.D['logvol'] = [-np.inf]
+            batch_sampler.saved_run.D['logl'] = [logl_min]
+            batch_sampler.saved_run.D['logz'] = [-1e100]
+            batch_sampler.saved_run.D['logzvar'] = [0]
+            batch_sampler.saved_run.D['h'] = [0]
         for it, results in enumerate(batch_sampler.add_live_points()):
             # Save results.
             D = dict(id=results.worst,

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -409,11 +409,11 @@ class Sampler:
         # within the remaining volume so that the expected volume enclosed
         # by the `i`-th worst likelihood is
         # `e^(-N / nlive) * (nlive + 1 - i) / (nlive + 1)`.
-        logvols = logvol + np.log(1. - (np.arange(self.nlive) + 1.) /
-                                  (self.nlive + 1.))
+        logvols = np.log(1. - (np.arange(self.nlive) + 1.) / (self.nlive + 1.))
 
         # Defining change in `logvol` used in `logzvar` approximation.
-        dlvs = -np.diff(logvols, prepend=logvol)
+        dlvs = -np.diff(logvols, prepend=0)
+        logvols += logvol
 
         # Sorting remaining live points.
         lsort_idx = np.argsort(self.live_logl)
@@ -446,7 +446,7 @@ class Sampler:
                                        logvol, dlv, h)
             loglstar = loglstar_new
             logz_remain = loglmax + logvol  # remaining ln(evidence)
-            delta_logz = np.logaddexp(logz, logz_remain) - logz  # dlogz
+            delta_logz = np.logaddexp(0, logz_remain - logz)
 
             # Save results.
             if self.save_samples:

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -399,29 +399,27 @@ class Sampler:
         else:
             self.added_live = True
 
+        logz = self.saved_run.D['logz'][-1]
+        logzvar = self.saved_run.D['logzvar'][-1]
+        h = self.saved_run.D['h'][-1]
+        loglstar = self.saved_run.D['logl'][-1]
+        logvol = self.saved_run.D['logvol'][-1]
         # After N samples have been taken out, the remaining volume is
         # `e^(-N / nlive)`. The remaining points are distributed uniformly
         # within the remaining volume so that the expected volume enclosed
         # by the `i`-th worst likelihood is
         # `e^(-N / nlive) * (nlive + 1 - i) / (nlive + 1)`.
-        logvols = self.saved_run.D['logvol'][-1]
-        logvols += np.log(1. - (np.arange(self.nlive) + 1.) /
-                          (self.nlive + 1.))
-        logvols_pad = np.concatenate(
-            ([self.saved_run.D['logvol'][-1]], logvols))
+        logvols = logvol + np.log(1. - (np.arange(self.nlive) + 1.) /
+                                  (self.nlive + 1.))
 
         # Defining change in `logvol` used in `logzvar` approximation.
-        dlvs = logvols_pad[:-1] - logvols_pad[1:]
+        dlvs = -np.diff(logvols, prepend=logvol)
 
         # Sorting remaining live points.
         lsort_idx = np.argsort(self.live_logl)
         loglmax = max(self.live_logl)
 
         # Grabbing relevant values from the last dead point.
-        logz = self.saved_run.D['logz'][-1]
-        logzvar = self.saved_run.D['logzvar'][-1]
-        h = self.saved_run.D['h'][-1]
-        loglstar = self.saved_run.D['logl'][-1]
         if self._beyond_unit_bound(loglstar):
             bounditer = self.nbound - 1
         else:


### PR DESCRIPTION
While running the notebooks I stumbled up on this bug:

```
  File "/tmp/qq.py", line 28, in <module>
    dsampler2.run_nested(maxiter=50000, use_stop=False)
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/dynesty/dynamicsampler.py", line 1810, in run_nested
    passback = self.add_batch(
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/dynesty/dynamicsampler.py", line 1973, in add_batch
    for cur_results in self.sample_batch(nlive_new=nlive,
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/dynesty/dynamicsampler.py", line 1392, in sample_batch
    for it, results in enumerate(batch_sampler.add_live_points()):
  File "/home/skoposov/pyenv38/lib/python3.8/site-packages/dynesty/sampler.py", line 407, in add_live_points
    logvols = self.saved_run.D['logvol'][-1]
IndexError: list index out of range

```

This can be reproduced with this:

```
mport dynesty
import numpy as np
from numpy import linalg

rstate = np.random.default_rng(513)
ndim = 3
C2 = np.identity(ndim)
Cinv2 = linalg.inv(C2)
lnorm2 = -0.5 * (np.log(2 * np.pi) * ndim + np.log(linalg.det(C2)))


def loglikelihood2(x):
    """Multivariate normal log-likelihood."""
    return -0.5 * np.dot(x, np.dot(Cinv2, x)) + lnorm2


# prior transform
def prior_transform(u):
    return 10. * (2. * u - 1.)


dsampler2 = dynesty.DynamicNestedSampler(loglikelihood2,
                                         prior_transform,
                                         ndim=3,
                                         bound='single',
                                         sample='unif',
                                         rstate=rstate)
dsampler2.run_nested(maxiter=50000, use_stop=False)
dres2 = dsampler2.results
```

This can be explained by 
* Batch sampling starting (with low logl boundary of -inf)
* Batch exhausting all the allowed iterations while creating nlive samples for the batch
* then sampling being no-op because of maxiter=0
* Failing in add_live_points because() there are no saved points to pick information such as logl/logvol from (and because we started from logl=-inf, so we didn't reuse any points from previous runs)


I this patch I fix the issue by fudging the logvol/logl arrays in the batch_sampler. 
This is not a pretty solution, but the best  I could come up with.

