### PR TITLE
Bounding update, getting rid of cholesky transform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,8 @@
 source =
        py/dynesty/
        **/site-packages/dynesty/
+
+[run]
+concurrency = multiprocessing
+parallel = true
+sigterm = true

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,6 @@ source =
 concurrency = multiprocessing
 parallel = true
 sigterm = true
+omit =
+     tests/*
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,4 +9,4 @@ parallel = true
 sigterm = true
 omit =
      tests/*
-
+source = dynesty

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,13 +43,13 @@ jobs:
         run: grep -e 'np\.random\.' py/*/*y  | ( ! grep -v plotting.py ) | ( ! grep -v SeedSe  ) | ( ! grep -v default_rng ) | (! grep -v Generator )
       - name: TestWithCov
         # Run coverage only for 3.6
-        if: ${{ matrix.python-version == '3.6'}}
+        if: ${{ matrix.python-version == '3.8'}}
         run: pytest --durations=0 -m "not slow" --cov=dynesty
       - name: Test
-        if: ${{ matrix.python-version != '3.6'}}
+        if: ${{ matrix.python-version != '3.8'}}
         run: pytest --durations=0 -m "not slow"
       - name: Coveralls
-        if: ${{ success() && ( matrix.python-version == '3.6') }}
+        if: ${{ success() && ( matrix.python-version == '3.8') }}
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/py/dynesty/bounding.py
+++ b/py/dynesty/bounding.py
@@ -116,10 +116,6 @@ class Ellipsoid:
         self.n = len(ctr)  # dimension
         self.ctr = np.asarray(ctr)  # center coordinates
         self.cov = np.asarray(cov)  # covariance matrix
-        if axes is None:
-            self.axes = lalg.cholesky(cov, lower=True)  # transformation axes
-        else:
-            self.axes = axes
 
         # The eigenvalues (l) of `a` are (a^-2, b^-2, ...) where
         # (a, b, ...) are the lengths of principle axes.
@@ -135,6 +131,10 @@ class Ellipsoid:
                 "The input precision matrix defining the "
                 f"ellipsoid {self.cov} is apparently singular with "
                 f"l={l} and v={v}.")
+        if axes is None:
+            self.axes = v @ np.diag(self.axlens)
+        else:
+            self.axes = axes
         if am is None:
             self.am = v @ np.diag(1. / l) @ v.T
             # precision matrix (inverse of covariance)
@@ -184,7 +184,7 @@ class Ellipsoid:
             self.cov = v @ np.diag(l1) @ v.T
             self.am = v @ np.diag(1 / l1) @ v.T
             self.axlens *= fax
-            self.axes = lalg.cholesky(self.cov, lower=True)
+            self.axes = self.axes @ np.diag(fax)
             # I don't quite know how to scale axes, so I rerun cholesky
         self.logvol = logvol
 
@@ -1230,12 +1230,7 @@ def improve_covar_mat(covar0, ntries=100, max_condition_number=1e12):
                         # some eigen values are too small
                         failed = 1
                     else:
-                        # eigen values are all right
-                        # checking if cholesky works
-                        axes = lalg.cholesky(covar,
-                                             lower=True,
-                                             check_finite=False)
-                        # if we are here we are done
+                        axes = eigvec @ np.diag(eigval**.5)
                         break
             else:
                 # complete failure
@@ -1259,8 +1254,8 @@ def improve_covar_mat(covar0, ntries=100, max_condition_number=1e12):
         warnings.warn("Failed to guarantee the ellipsoid axes will be "
                       "non-singular. Defaulting to a sphere.")
         covar = np.eye(ndim)  # default to identity
-        am = lalg.pinvh(covar)
-        axes = lalg.cholesky(covar, lower=True)
+        am = covar.copy()
+        axes = covar.copy()
     else:
         # invert the matrix using eigen decomposition
         am = eigvec @ np.diag(1. / eigval) @ eigvec.T

--- a/py/dynesty/pool.py
+++ b/py/dynesty/pool.py
@@ -137,11 +137,7 @@ class Pool:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
-            self.pool.close()
-        except:  # noqa
-            pass
-        try:
-            self.pool.join()
+            self.pool.terminate()
         except:  # noqa
             pass
 
@@ -151,3 +147,9 @@ class Pool:
         Return the number of processes in the pool
         """
         return self.njobs
+
+    def close(self):
+        self.pool.close()
+
+    def join(self):
+        self.pool.join()

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -43,6 +43,7 @@ LOGZ_TRUTH_EGG = 235.856
 def test_pool():
     # test pool on egg problem
     rstate = get_rstate()
+
     # i specify large queue_size here, otherwise it is too slow
     with dypool.Pool(2, loglike_egg, prior_transform_egg) as pool:
         sampler = dynesty.NestedSampler(pool.loglike,
@@ -61,6 +62,7 @@ def test_pool():
 def test_pool_x():
     # check without specifying queue_size
     rstate = get_rstate()
+
     with dypool.Pool(2, loglike_egg, prior_transform_egg) as pool:
         sampler = dynesty.NestedSampler(pool.loglike,
                                         pool.prior_transform,
@@ -78,6 +80,7 @@ def test_pool_dynamic():
     # test pool on gau problem
     # i specify large queue_size here, otherwise it is too slow
     rstate = get_rstate()
+
     with dypool.Pool(2, loglike_gau, prior_transform_gau) as pool:
         sampler = dynesty.DynamicNestedSampler(pool.loglike,
                                                pool.prior_transform,
@@ -105,6 +108,7 @@ def test_pool_args():
     # test pool on gau problem
     # i specify large queue_size here, otherwise it is too slow
     rstate = get_rstate()
+
     with dypool.Pool(2,
                      loglike_gau_args,
                      prior_transform_gau_args,
@@ -124,11 +128,16 @@ def test_pool_args():
         assert (abs(LOGZ_TRUTH_GAU - sampler.results['logz'][-1]) <
                 5. * sampler.results['logzerr'][-1])
 
+        # to ensure we get coverage
+        pool.close()
+        pool.join()
+
 
 @pytest.mark.parametrize('sample', ['slice', 'rwalk', 'rslice'])
 def test_pool_samplers(sample):
     # this is to test how the samplers are dealing with queue_size>1
     rstate = get_rstate()
+
     with mp.Pool(2) as pool:
         sampler = dynesty.NestedSampler(loglike_gau,
                                         prior_transform_gau,
@@ -154,6 +163,7 @@ def test_usepool(func):
     for k in POOL_KW:
         use_pool[k] = False
     use_pool[func] = True
+
     with mp.Pool(2) as pool:
         sampler = dynesty.DynamicNestedSampler(loglike_gau,
                                                prior_transform_gau,


### PR DESCRIPTION
To avoid forgetting this PR gets rid of cholesky transform when constructing ellipsoids. 
The reason is that since we are doing eigen transform anyway, we don't need to do cholesky on top. 
The transformation matrix from normal coordinates to ellipsoidal coordinates can be done with cholesky matrix L (where L L^T =C ) or through sqrt(L) V where (L is vector of eigen values and V are eigen vectors). 

This speeds up the tests somewhat. On my machine it seems to be ~ 10%. 
 
Also I relaxed one condition when checking whether the point belongs to multiple ellipsoids (in the hope of dealing with #396). 
Whether that is enough or not I don't know. 