### PR TITLE
fix the resuming of dynamic nested sampler runs with the pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 ### Fixed
 - Fix the restoration of the dynamic sampler from the checkpoint with the pool. Previously after restoring the sampler, the pool was not used. (#438 ; by @segasai)
+- Fix the issue with checkpointing from the dynamic sampler. Previously if one batch took shorter than the checkpoint_every seconds then the checkpoints were  not created
 
 ## [2.1.1] - 2023-04-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 ### Changed
+### Fixed
+- Fix the restoration of the dynamic sampler from the checkpoint with the pool. Previously after restoring the sampler, the pool was not used. (#438 ; by @segasai)
 
 ## [2.1.1] - 2023-04-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 ### Fixed
 - Fix the restoration of the dynamic sampler from the checkpoint with the pool. Previously after restoring the sampler, the pool was not used. (#438 ; by @segasai)
-- Fix the issue with checkpointing from the dynamic sampler. Previously if one batch took shorter than the checkpoint_every seconds then the checkpoints were  not created
+- Fix the issue with checkpointing from the dynamic sampler. Previously if one batch took shorter than the checkpoint_every seconds then the checkpoints were  not created (by @segasai)
+- Fix the restoration from checkpoint that could have occassiounaly lead to one skipped point from nested run (by @segasai)
 
 ## [2.1.1] - 2023-04-16
 ### Added

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -301,8 +301,8 @@ class Sampler:
         if ncall is None:
             ncall = self.ncall
         call_check_first = (ncall >= self.first_bound_update_ncall)
-        call_check = (ncall >=
-                      self.bound_update_interval + self.ncall_at_last_update)
+        call_check = (ncall >= self.bound_update_interval +
+                      self.ncall_at_last_update)
         efficiency_check = (self.eff < self.first_bound_update_eff)
         # there are three cases when we update the bound
         # * if we are still using uniform cube sampling and both efficiency is
@@ -732,11 +732,10 @@ class Sampler:
                 self._remove_live_points()
 
             # Get final state from previous run.
-            h, logz, logzvar, logvol = [
+            h, logz, logzvar, logvol, loglstar = [
                 self.saved_run[_][-1]
-                for _ in ['h', 'logz', 'logzvar', 'logvol']
+                for _ in ['h', 'logz', 'logzvar', 'logvol', 'logl']
             ]
-            loglstar = np.min(self.live_logl)  # ln(likelihood)
             delta_logz = np.logaddexp(0,
                                       np.max(self.live_logl) + logvol - logz)
 

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -312,16 +312,16 @@ class DelayTimer:
     """ Utility class that allows us to detect a certain
     time has passed"""
 
-    def __init__(self, dt):
+    def __init__(self, delay):
         """ Initialise the time with delay of dt seconds
 
         Parameters
         ----------
 
-        dt: float
+        delay: float
             The number of seconds in the timer
         """
-        self.dt = dt
+        self.delay = delay
         self.last_time = time.time()
 
     def is_time(self):
@@ -336,7 +336,7 @@ class DelayTimer:
              initialization or last successful is_time() call
         """
         curt = time.time()
-        if curt - self.last_time > self.dt:
+        if curt - self.last_time > self.delay:
             self.last_time = curt
             return True
         return False

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -2274,13 +2274,20 @@ def restore_sampler(fname, pool=None):
             f'does not match the current dynesty version'
             '({DYNESTY_VERSION}). That is *NOT* guaranteed to work')
     if pool is not None:
+        mapper = pool.map
+    else:
+        mapper = map
+    if hasattr(sampler, 'sampler'):
+        # This is the case of th dynamic sampler
+        # this is better be written as isinstanceof()
+        # but I couldn't do it due to circular imports
+        # TODO
+        sampler.sampler.M = mapper
+        sampler.sampler.pool = pool
+    else:
         sampler.M = pool.map
         sampler.pool = pool
-        sampler.loglikelihood.pool = pool
-    else:
-        sampler.loglikelihood.pool = None
-        sampler.pool = None
-        sampler.M = map
+    sampler.loglikelihood.pool = pool
     return sampler
 
 

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -2285,7 +2285,7 @@ def restore_sampler(fname, pool=None):
         sampler.sampler.M = mapper
         sampler.sampler.pool = pool
     else:
-        sampler.M = pool.map
+        sampler.M = mapper
         sampler.pool = pool
     sampler.loglikelihood.pool = pool
     return sampler

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -402,13 +402,13 @@ def test_deterministic(ndim):
 def test_update_interval(dyn):
     # test that we can set update_interval
     ndim = 2
-    rstate = get_rstate()
     bigres = {}
     if dyn:
         CL = dynesty.DynamicNestedSampler
     else:
         CL = dynesty.NestedSampler
     for i in range(3):
+        rstate = get_rstate()
         if i == 0:
             update_interval = None
         elif i == 1:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -63,8 +63,8 @@ def test_pool():
                                         rstate=rstate)
         sampler.run_nested(dlogz=0.1, print_progress=printing)
 
-        assert (abs(LOGZ_TRUTH_EGG - sampler.results['logz'][-1]) <
-                5. * sampler.results['logzerr'][-1])
+        assert (abs(LOGZ_TRUTH_EGG - sampler.results['logz'][-1])
+                < 5. * sampler.results['logzerr'][-1])
         terminator(pool)
 
 
@@ -78,11 +78,12 @@ def test_pool_x():
                                         ndim,
                                         nlive=50,
                                         pool=pool,
+                                        queue_size=100,
                                         rstate=rstate)
         sampler.run_nested(print_progress=printing, maxiter=100)
 
-        assert (abs(LOGZ_TRUTH_EGG - sampler.results['logz'][-1]) <
-                5. * sampler.results['logzerr'][-1])
+        assert (abs(LOGZ_TRUTH_EGG - sampler.results['logz'][-1])
+                < 5. * sampler.results['logzerr'][-1])
         terminator(pool)
 
 
@@ -101,8 +102,8 @@ def test_pool_dynamic():
                                                rstate=rstate)
         sampler.run_nested(dlogz_init=1, print_progress=printing)
 
-        assert (abs(LOGZ_TRUTH_GAU - sampler.results['logz'][-1]) <
-                5. * sampler.results['logzerr'][-1])
+        assert (abs(LOGZ_TRUTH_GAU - sampler.results['logz'][-1])
+                < 5. * sampler.results['logzerr'][-1])
         terminator(pool)
 
 
@@ -136,8 +137,8 @@ def test_pool_args():
                                                rstate=rstate)
         sampler.run_nested(maxiter=300, print_progress=printing)
 
-        assert (abs(LOGZ_TRUTH_GAU - sampler.results['logz'][-1]) <
-                5. * sampler.results['logzerr'][-1])
+        assert (abs(LOGZ_TRUTH_GAU - sampler.results['logz'][-1])
+                < 5. * sampler.results['logzerr'][-1])
 
         # to ensure we get coverage
         terminator(pool)
@@ -155,11 +156,11 @@ def test_pool_samplers(sample):
                                         nlive=nlive,
                                         sample=sample,
                                         pool=pool,
-                                        queue_size=10,
+                                        queue_size=100,
                                         rstate=rstate)
         sampler.run_nested(print_progress=printing)
-        assert (abs(LOGZ_TRUTH_GAU - sampler.results['logz'][-1]) <
-                5. * sampler.results['logzerr'][-1])
+        assert (abs(LOGZ_TRUTH_GAU - sampler.results['logz'][-1])
+                < 5. * sampler.results['logzerr'][-1])
         terminator(pool)
 
 

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -49,7 +49,7 @@ def fit_main(fname,
     ndim = 2
     with (NullContextManager() if npool is None else (dynesty.pool.Pool(
             npool, like, ptform) if dyn_pool else mp.Pool(npool))) as pool:
-        queue_size = npool
+        queue_size = 100 if npool is not None else None
         if dyn_pool:
             curlike, curpt = pool.loglike, pool.prior_transform
         else:

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,15 +1,15 @@
+import inspect
+import itertools
 import os
-import time
 import sys
+import time
+import warnings
 import multiprocessing as mp
 import dynesty
 import numpy as np
 import pytest
 from utils import get_rstate, NullContextManager, get_printing
-import itertools
 import dynesty.pool
-import inspect
-import os
 
 printing = get_printing()
 
@@ -173,6 +173,12 @@ def test_resume(dynamic, delay_frac, with_pool, dyn_pool):
                 # in the case of pooled run do not compare
                 # as I am comparing with single threaded version
                 curres = None
+            if np.allclose(delay_frac, .2) and not os.path.exists(fname):
+                warnings.warn(
+                    "The checkpoint file was not created I'm skipping the test"
+                )
+                return
+
             with (NullContextManager() if npool is None else
                   (dynesty.pool.Pool(npool, like, ptform)
                    if dyn_pool else mp.Pool(npool))) as pool:


### PR DESCRIPTION
Addresses #438 

What remains to be done here is some kind of test that would prevent this bug from happening.
I.e. the test that would verify that after restoring with the pool, it's actually used. 

If I won't have an idea for the test, I'll be merging without. 
