### PR TITLE
get rid of npdim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 [Unreleased]
 ### Added
+
 ### Changed
+- Get rid of npdim option that at some point may have allowed the prior transformation to return higher dimensional vector than the inputs. Note that due to this change, restoring the checkpoint from previous version of the dynesty won't be possible) (issues #456, #457) (original issue reported by @MichaelDAlbrow, fixed by @segasai )
 ### Fixed
 
 

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -345,7 +345,7 @@ def _initialize_live_points(live_points,
                             loglikelihood,
                             M,
                             nlive=None,
-                            npdim=None,
+                            ndim=None,
                             rstate=None,
                             blob=False,
                             use_pool_ptform=None):
@@ -372,7 +372,7 @@ def _initialize_live_points(live_points,
     nlive: int
         Number of live-points
 
-    npdim: int
+    ndim: int
         Number of dimensions
 
     rstate: :class: numpy.random.RandomGenerator
@@ -403,13 +403,13 @@ def _initialize_live_points(live_points,
         # sampling from the unit cube.
         n_attempts = 1000
 
-        min_npoints = min(nlive, max(npdim + 1, min(nlive - 20, 100)))
+        min_npoints = min(nlive, max(ndim + 1, min(nlive - 20, 100)))
         # the minimum number points we want with finite logl
-        # we want want at least npdim+1, because we want
+        # we want want at least ndim+1, because we want
         # to be able to constraint the ellipsoid
-        # Note that if nlive <npdim+ 1 this doesn't really make sense
+        # Note that if nlive <ndim+ 1 this doesn't really make sense
         # but we should have warned the user earlier, so they are on their own
-        # And the reason we have max(npdim+1, X ) is that we'd like to get at
+        # And the reason we have max(ndim+1, X ) is that we'd like to get at
         # least X points as otherwise the poisson estimate of the volume will
         # be too large.
         # The reason why X is min(nlive-20, 100) is that we want at least 100
@@ -419,8 +419,8 @@ def _initialize_live_points(live_points,
         # integrals and batch sampling in plateau edge tests
         # The formula probably should be simplified
 
-        live_u = np.zeros((nlive, npdim))
-        live_v = np.zeros((nlive, npdim))
+        live_u = np.zeros((nlive, ndim))
+        live_v = np.zeros((nlive, ndim))
         live_logl = np.zeros(nlive)
         ngoods = 0  # counter for how many finite logl we have found
         live_blobs = []
@@ -429,7 +429,7 @@ def _initialize_live_points(live_points,
             iattempt += 1
 
             # simulate nlive points by uniform sampling
-            cur_live_u = rstate.random(size=(nlive, npdim))
+            cur_live_u = rstate.random(size=(nlive, ndim))
             if use_pool_ptform:
                 cur_live_v = M(prior_transform, np.asarray(cur_live_u))
             else:
@@ -611,7 +611,7 @@ def _configure_batch_sampler(main_sampler,
     batch_sampler = _SAMPLERS[main_sampler.bounding](
         main_sampler.loglikelihood,
         main_sampler.prior_transform,
-        main_sampler.npdim,
+        main_sampler.ndim,
         main_sampler.live_init,  # this is not used at all
         # as we replace the starting points
         main_sampler.method,
@@ -658,7 +658,7 @@ def _configure_batch_sampler(main_sampler,
              main_sampler.loglikelihood,
              main_sampler.M,
              nlive=nlive_new,
-             npdim=main_sampler.npdim,
+             ndim=main_sampler.ndim,
              rstate=main_sampler.rstate,
              blob=main_sampler.blob,
              use_pool_ptform=main_sampler.use_pool_ptform)
@@ -776,7 +776,7 @@ def _configure_batch_sampler(main_sampler,
         # Trigger an update of the internal bounding distribution based
         # on the "new" set of live points.
 
-        live_u = np.empty((nlive_new, main_sampler.npdim))
+        live_u = np.empty((nlive_new, main_sampler.ndim))
         live_v = np.empty((nlive_new, saved_v.shape[1]))
         live_logl = np.empty(nlive_new)
         live_bound = np.zeros(nlive_new, dtype=int)
@@ -867,7 +867,7 @@ class DynamicSampler:
         Function transforming a sample from the a unit cube to the parameter
         space of interest according to the prior.
 
-    npdim : int, optional
+    ndim : int, optional
         Number of parameters accepted by `prior_transform`.
 
     bound : {`'none'`, `'single'`, `'multi'`, `'balls'`, `'cubes'`}, optional
@@ -913,14 +913,14 @@ class DynamicSampler:
         A dictionary of additional parameters (described below).
     """
 
-    def __init__(self, loglikelihood, prior_transform, npdim, bound, method,
+    def __init__(self, loglikelihood, prior_transform, ndim, bound, method,
                  update_interval_ratio, first_update, rstate, queue_size, pool,
                  use_pool, ncdim, nlive0, kwargs):
 
         # distributions
         self.loglikelihood = loglikelihood
         self.prior_transform = prior_transform
-        self.npdim = npdim
+        self.ndim = ndim
         self.ncdim = ncdim
         self.blob = kwargs.get('blob') or False
         # bounding/sampling
@@ -1205,7 +1205,7 @@ class DynamicSampler:
             Contains `live_u`, the coordinates on the unit cube, `live_v`, the
             transformed variables, and `live_logl`, the associated
             loglikelihoods. By default, if these are not provided the initial
-            set of live points will be drawn from the unit `npdim`-cube.
+            set of live points will be drawn from the unit `ndim`-cube.
             **WARNING: It is crucial that the initial set of live points have
             been sampled from the prior. Failure to provide a set of valid
             live points will lead to incorrect results.**
@@ -1216,7 +1216,7 @@ class DynamicSampler:
             Index of the live point with the worst likelihood. This is our
             new dead point sample.
 
-        ustar : `~numpy.ndarray` with shape (npdim,)
+        ustar : `~numpy.ndarray` with shape (ndim,)
             Position of the sample.
 
         vstar : `~numpy.ndarray` with shape (ndim,)
@@ -1292,7 +1292,7 @@ class DynamicSampler:
                  self.loglikelihood,
                  self.M,
                  nlive=nlive,
-                 npdim=self.npdim,
+                 ndim=self.ndim,
                  rstate=self.rstate,
                  blob=self.blob,
                  use_pool_ptform=self.use_pool_ptform)
@@ -1317,7 +1317,7 @@ class DynamicSampler:
                 first_update = self.first_update
             self.sampler = _SAMPLERS[bounding](self.loglikelihood,
                                                self.prior_transform,
-                                               self.npdim,
+                                               self.ndim,
                                                self.live_init,
                                                self.method,
                                                update_interval,
@@ -1502,7 +1502,7 @@ class DynamicSampler:
             new dead point sample. **Negative values indicate the index
             of a new live point generated when initializing a new batch.**
 
-        ustar : `~numpy.ndarray` with shape (npdim,)
+        ustar : `~numpy.ndarray` with shape (ndim,)
             Position of the sample.
 
         vstar : `~numpy.ndarray` with shape (ndim,)
@@ -1972,7 +1972,7 @@ class DynamicSampler:
             Contains `live_u`, the coordinates on the unit cube, `live_v`, the
             transformed variables, and `live_logl`, the associated
             loglikelihoods. By default, if these are not provided the initial
-            set of live points will be drawn from the unit `npdim`-cube.
+            set of live points will be drawn from the unit `ndim`-cube.
             **WARNING: It is crucial that the initial set of live points have
             been sampled from the prior. Failure to provide a set of valid
             live points will lead to incorrect results.**
@@ -2028,7 +2028,7 @@ class DynamicSampler:
                 # The reason to scale with square of number of
                 # dimensions is because the number coefficients
                 # defining covariance is roughly 0.5 * N^2
-                n_effective = max(self.npdim * self.npdim, 10000)
+                n_effective = max(self.ndim * self.ndim, 10000)
 
             stop_kwargs['target_n_effective'] = n_effective
         nlive_init = nlive_init or self.nlive0

--- a/py/dynesty/dynesty.py
+++ b/py/dynesty/dynesty.py
@@ -329,13 +329,6 @@ optional
             efficiency in percent (`'min_eff'`). Defaults are `2 * nlive` and
             `10.`, respectively.
 
-        npdim : int, optional
-            Number of parameters accepted by `prior_transform`. This might
-            differ from `ndim` in the case where a parameter of loglikelihood
-            is dependent upon multiple independently distributed parameters,
-            some of which may
-            be nuisance parameters.
-
         rstate : `~numpy.random.Generator`, optional
             `~numpy.random.Generator` instance. If not given, the
              global random state of the `~numpy.random` module will be used.
@@ -370,7 +363,7 @@ optional
             transformed variables, and `live_logl`, the associated
             loglikelihoods.
             By default, if these are not provided the initial set of live
-            points will be drawn uniformly from the unit `npdim`-cube.
+            points will be drawn uniformly from the unit `ndim`-cube.
             **WARNING: It is crucial that the initial set of live points have
             been sampled from the prior. Failure to provide a set of valid
             live points
@@ -468,13 +461,16 @@ optional
             will be sampled using the sampling method, the remaining
             dimensions will
             just sample uniformly from the prior distribution.
-            If this is `None` (default), this will default to npdim.
+            If this is `None` (default), this will default to ndim.
 
         blob: bool, optional
             The default value is False. If it is true, then the log-likelihood
             should return the tuple of logl and a numpy-array "blob" that will
             stored as part of the chain. That blob can contain auxiliary
             information computed inside the likelihood function.
+
+        npdim : int
+            This option is deprecated and should not be used 
     """
 
     static_docstring = f"""
@@ -548,10 +544,15 @@ class NestedSampler(SuperSampler):
                 history_filename=None):
 
         # Prior dimensions.
-        if npdim is None:
-            npdim = ndim
-        if ncdim is None:
-            ncdim = npdim
+        if npdim is not None:
+            if npdim != ndim:
+                raise ValueError('''npdim functionality is not functioning 
+and is deprecated ''')
+            else:
+                warnings.warn(
+                    """the npdim keyword/functionality is deprecated as not 
+functioning and will be removed in further releases""", DeprecationWarning)
+        ncdim = ncdim or ndim
 
         # Bounding method.
         if bound not in _SAMPLERS:
@@ -563,7 +564,7 @@ class NestedSampler(SuperSampler):
 
         walks, slices = _get_walks_slices(walks, slices, sample, ndim)
 
-        if ncdim != npdim and sample in ['slice', 'hslice', 'rslice']:
+        if ncdim != ndim and sample in ['slice', 'hslice', 'rslice']:
             raise ValueError('ncdim unsupported for slice sampling')
 
         # Custom sampling function.
@@ -585,7 +586,7 @@ class NestedSampler(SuperSampler):
             warnings.warn(
                 "Beware! Having `nlive <= 2 * ndim` is extremely risky!")
 
-        nonbounded = get_nonbounded(npdim, periodic, reflective)
+        nonbounded = get_nonbounded(ndim, periodic, reflective)
         kwargs['nonbounded'] = nonbounded
         kwargs['periodic'] = periodic
         kwargs['reflective'] = reflective
@@ -680,7 +681,7 @@ class NestedSampler(SuperSampler):
             loglike,
             M,
             nlive=nlive,
-            npdim=npdim,
+            ndim=ndim,
             rstate=rstate,
             blob=blob,
             use_pool_ptform=use_pool.get('prior_transform', True))
@@ -689,7 +690,7 @@ class NestedSampler(SuperSampler):
         sampler = super().__new__(_SAMPLERS[bound])
         sampler.__init__(loglike,
                          ptform,
-                         npdim,
+                         ndim,
                          live_points,
                          sample,
                          update_interval,
@@ -754,11 +755,15 @@ class DynamicNestedSampler(DynamicSampler):
                  history_filename=None):
 
         # Prior dimensions.
-        if npdim is None:
-            npdim = ndim
-        if ncdim is None:
-            ncdim = npdim
-
+        if npdim is not None:
+            if npdim != ndim:
+                raise ValueError('''npdim functionality is not functioning 
+and is deprecated ''')
+            else:
+                warnings.warn(
+                    """the npdim keyword/functionality is deprecated as not 
+functioning and will be removed in further releases""", DeprecationWarning)
+        ncdim = ncdim or ndim
         nlive = nlive or 500
 
         # Bounding method.
@@ -771,7 +776,7 @@ class DynamicNestedSampler(DynamicSampler):
 
         walks, slices = _get_walks_slices(walks, slices, sample, ndim)
 
-        if ncdim != npdim and sample in ['slice', 'hslice', 'rslice']:
+        if ncdim != ndim and sample in ['slice', 'hslice', 'rslice']:
             raise ValueError('ncdim unsupported for slice sampling')
 
         update_interval_ratio = _get_update_interval_ratio(
@@ -791,7 +796,7 @@ class DynamicNestedSampler(DynamicSampler):
         # Citation generator.
         kwargs['cite'] = _get_citations('dynamic', bound, sample)
 
-        nonbounded = get_nonbounded(npdim, periodic, reflective)
+        nonbounded = get_nonbounded(ndim, periodic, reflective)
         kwargs['nonbounded'] = nonbounded
         kwargs['periodic'] = periodic
         kwargs['reflective'] = reflective
@@ -877,7 +882,7 @@ class DynamicNestedSampler(DynamicSampler):
             kwargs['compute_jac'] = compute_jac
 
         # Initialize our nested sampler.
-        super().__init__(loglike, ptform, npdim, bound, sample,
+        super().__init__(loglike, ptform, ndim, bound, sample,
                          update_interval_ratio, first_update, rstate,
                          queue_size, pool, use_pool, ncdim, nlive, kwargs)
 

--- a/py/dynesty/nestedsamplers.py
+++ b/py/dynesty/nestedsamplers.py
@@ -58,7 +58,7 @@ class SuperSampler(Sampler):
     def __init__(self,
                  loglikelihood,
                  prior_transform,
-                 npdim,
+                 ndim,
                  live_points,
                  method,
                  update_interval,
@@ -74,7 +74,7 @@ class SuperSampler(Sampler):
         # Initialize sampler.
         super().__init__(loglikelihood,
                          prior_transform,
-                         npdim,
+                         ndim,
                          live_points,
                          update_interval,
                          first_update,
@@ -295,7 +295,7 @@ class UnitCubeSampler(SuperSampler):
         Function transforming a sample from the a unit cube to the parameter
         space of interest according to the prior.
 
-    npdim : int
+    ndim : int
         Number of parameters accepted by `prior_transform`.
 
     live_points : list of 3 `~numpy.ndarray` each with shape (nlive, ndim)
@@ -339,7 +339,7 @@ class UnitCubeSampler(SuperSampler):
     def __init__(self,
                  loglikelihood,
                  prior_transform,
-                 npdim,
+                 ndim,
                  live_points,
                  method,
                  update_interval,
@@ -356,7 +356,7 @@ class UnitCubeSampler(SuperSampler):
         # Initialize sampler.
         super().__init__(loglikelihood,
                          prior_transform,
-                         npdim,
+                         ndim,
                          live_points,
                          method,
                          update_interval,
@@ -383,10 +383,10 @@ class UnitCubeSampler(SuperSampler):
         within the unit cube."""
 
         u = self.unitcube.sample(rstate=self.rstate)
-        ax = np.identity(self.npdim)
-        if self.npdim != self.ncdim:
+        ax = np.identity(self.ndim)
+        if self.ndim != self.ncdim:
             u = np.concatenate(
-                [u, self.rstate.random(size=self.npdim - self.ncdim)])
+                [u, self.rstate.random(size=self.ndim - self.ncdim)])
 
         return u, ax
 
@@ -400,7 +400,7 @@ class UnitCubeSampler(SuperSampler):
         else:
             i = self.rstate.integers(self.nlive)
         u = self.live_u[i, :]
-        ax = np.identity(self.npdim)
+        ax = np.identity(self.ndim)
 
         return u, ax
 
@@ -420,7 +420,7 @@ class SingleEllipsoidSampler(SuperSampler):
         Function transforming a sample from the a unit cube to the parameter
         space of interest according to the prior.
 
-    npdim : int
+    ndim : int
         Number of parameters accepted by `prior_transform`.
 
     live_points : list of 3 `~numpy.ndarray` each with shape (nlive, ndim)
@@ -464,7 +464,7 @@ class SingleEllipsoidSampler(SuperSampler):
     def __init__(self,
                  loglikelihood,
                  prior_transform,
-                 npdim,
+                 ndim,
                  live_points,
                  method,
                  update_interval,
@@ -481,7 +481,7 @@ class SingleEllipsoidSampler(SuperSampler):
         # Initialize sampler.
         super().__init__(loglikelihood,
                          prior_transform,
-                         npdim,
+                         ndim,
                          live_points,
                          method,
                          update_interval,
@@ -527,7 +527,7 @@ class SingleEllipsoidSampler(SuperSampler):
         within the ellipsoid."""
 
         threshold_warning = 10000
-        if self.ncdim != self.npdim and self.nonbounded is not None:
+        if self.ncdim != self.ndim and self.nonbounded is not None:
             nonb = self.nonbounded[:self.ncdim]
         else:
             nonb = self.nonbounded
@@ -545,9 +545,9 @@ class SingleEllipsoidSampler(SuperSampler):
                 warnings.filterwarnings("once")
                 warnings.warn("Ellipsoid sampling is extremely inefficient")
 
-        if self.npdim != self.ncdim:
+        if self.ndim != self.ncdim:
             u = np.concatenate(
-                [u, self.rstate.random(size=self.npdim - self.ncdim)])
+                [u, self.rstate.random(size=self.ndim - self.ncdim)])
         return u, self.ell.axes
 
     def propose_live(self, *args):
@@ -584,7 +584,7 @@ class MultiEllipsoidSampler(SuperSampler):
         Function transforming a sample from the a unit cube to the parameter
         space of interest according to the prior.
 
-    npdim : int
+    ndim : int
         Number of parameters accepted by `prior_transform`.
 
     live_points : list of 3 `~numpy.ndarray` each with shape (nlive, ndim)
@@ -628,7 +628,7 @@ class MultiEllipsoidSampler(SuperSampler):
     def __init__(self,
                  loglikelihood,
                  prior_transform,
-                 npdim,
+                 ndim,
                  live_points,
                  method,
                  update_interval,
@@ -644,7 +644,7 @@ class MultiEllipsoidSampler(SuperSampler):
         # Initialize sampler.
         super().__init__(loglikelihood,
                          prior_transform,
-                         npdim,
+                         ndim,
                          live_points,
                          method,
                          update_interval,
@@ -691,7 +691,7 @@ class MultiEllipsoidSampler(SuperSampler):
 
         threshold_warning = 10000
 
-        if self.ncdim != self.npdim and self.nonbounded is not None:
+        if self.ncdim != self.ndim and self.nonbounded is not None:
             nonb = self.nonbounded[:self.ncdim]
         else:
             nonb = self.nonbounded
@@ -711,9 +711,9 @@ class MultiEllipsoidSampler(SuperSampler):
             with warnings.catch_warnings():
                 warnings.filterwarnings("once")
                 warnings.warn("Ellipsoid sampling is extremely inefficient")
-        if self.ncdim != self.npdim:
+        if self.ncdim != self.ndim:
             u = np.concatenate(
-                [u, self.rstate.random(size=self.npdim - self.ncdim)])
+                [u, self.rstate.random(size=self.ndim - self.ncdim)])
         return u, self.mell.ells[idx].axes
 
     def propose_live(self, *args):
@@ -749,7 +749,7 @@ class MultiEllipsoidSampler(SuperSampler):
             # Choose axes.
             ax = self.mell.ells[ell_idx].axes
         else:
-            ax = np.identity(self.npdim)
+            ax = np.identity(self.ndim)
 
         return u, ax
 
@@ -769,7 +769,7 @@ class RadFriendsSampler(SuperSampler):
         Function transforming a sample from the a unit cube to the parameter
         space of interest according to the prior.
 
-    npdim : int
+    ndim : int
         Number of parameters accepted by `prior_transform`.
 
     live_points : list of 3 `~numpy.ndarray` each with shape (nlive, ndim)
@@ -813,7 +813,7 @@ class RadFriendsSampler(SuperSampler):
     def __init__(self,
                  loglikelihood,
                  prior_transform,
-                 npdim,
+                 ndim,
                  live_points,
                  method,
                  update_interval,
@@ -830,7 +830,7 @@ class RadFriendsSampler(SuperSampler):
         # Initialize sampler.
         super().__init__(loglikelihood,
                          prior_transform,
-                         npdim,
+                         ndim,
                          live_points,
                          method,
                          update_interval,
@@ -889,7 +889,7 @@ class RadFriendsSampler(SuperSampler):
         ax = self.radfriends.axes
 
         u = np.concatenate(
-            [u, self.rstate.random(size=self.npdim - self.ncdim)])
+            [u, self.rstate.random(size=self.ndim - self.ncdim)])
         return u, ax
 
     def propose_live(self, *args):
@@ -923,7 +923,7 @@ class SupFriendsSampler(SuperSampler):
         Function transforming a sample from the a unit cube to the parameter
         space of interest according to the prior.
 
-    npdim : int
+    ndim : int
         Number of parameters accepted by `prior_transform`.
 
     live_points : list of 3 `~numpy.ndarray` each with shape (nlive, ndim)
@@ -967,7 +967,7 @@ class SupFriendsSampler(SuperSampler):
     def __init__(self,
                  loglikelihood,
                  prior_transform,
-                 npdim,
+                 ndim,
                  live_points,
                  method,
                  update_interval,
@@ -984,7 +984,7 @@ class SupFriendsSampler(SuperSampler):
         # Initialize sampler.
         super().__init__(loglikelihood,
                          prior_transform,
-                         npdim,
+                         ndim,
                          live_points,
                          method,
                          update_interval,
@@ -1042,9 +1042,9 @@ class SupFriendsSampler(SuperSampler):
 
         # Define the axes of our N-cube.
         ax = self.supfriends.axes
-        if self.npdim != self.ncdim:
+        if self.ndim != self.ncdim:
             u = np.concatenate(
-                [u, self.rstate.random(size=self.npdim - self.ncdim)])
+                [u, self.rstate.random(size=self.ndim - self.ncdim)])
         return u, ax
 
     def propose_live(self, *args):

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -35,7 +35,7 @@ class Sampler:
         Function transforming a sample from the a unit cube to the parameter
         space of interest according to the prior.
 
-    npdim : int, optional
+    ndim : int, optional
         Number of parameters accepted by `prior_transform`.
 
     live_points : list of 3 `~numpy.ndarray` each with shape (nlive, ndim)
@@ -71,7 +71,7 @@ class Sampler:
     def __init__(self,
                  loglikelihood,
                  prior_transform,
-                 npdim,
+                 ndim,
                  live_points,
                  update_interval,
                  first_update,
@@ -86,7 +86,7 @@ class Sampler:
         # distributions
         self.loglikelihood = loglikelihood
         self.prior_transform = prior_transform
-        self.npdim = npdim
+        self.ndim = ndim
         self.ncdim = ncdim
         self.blob = blob
         # live points
@@ -189,7 +189,7 @@ class Sampler:
         """Re-initialize the sampler."""
 
         # live points
-        self.live_u = self.rstate.random(size=(self.nlive, self.npdim))
+        self.live_u = self.rstate.random(size=(self.nlive, self.ndim))
         if self.use_pool_ptform:
             # Use the pool to compute the prior transform.
             self.live_v = np.array(
@@ -365,7 +365,7 @@ class Sampler:
         else:
             # Propose/evaluate points directly from the unit cube.
             point_queue = self.rstate.random(size=(self.queue_size -
-                                                   self.nqueue, self.npdim))
+                                                   self.nqueue, self.ndim))
             axes_queue = np.identity(
                 self.ncdim)[None, :, :] + np.zeros(self.queue_size -
                                                    self.nqueue)[:, None, None]
@@ -661,7 +661,7 @@ class Sampler:
             Index of the live point with the worst likelihood. This is our
             new dead point sample.
 
-        ustar : `~numpy.ndarray` with shape (npdim,)
+        ustar : `~numpy.ndarray` with shape (ndim,)
             Position of the sample.
 
         vstar : `~numpy.ndarray` with shape (ndim,)

--- a/py/dynesty/sampling.py
+++ b/py/dynesty/sampling.py
@@ -35,7 +35,7 @@ def sample_unif(args):
 
     Parameters
     ----------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the initial sample.
 
     loglstar : float
@@ -61,7 +61,7 @@ def sample_unif(args):
 
     Returns
     -------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the final proposed point within the unit cube. **For
         uniform sampling this is the same as the initial input position.**
 
@@ -99,7 +99,7 @@ def sample_rwalk(args):
 
     Parameters
     ----------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the initial sample. **This is a copy of an existing live
         point.**
 
@@ -127,7 +127,7 @@ def sample_rwalk(args):
 
     Returns
     -------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the final proposed point within the unit cube.
 
     v : `~numpy.ndarray` with shape (ndim,)
@@ -157,7 +157,7 @@ def generic_random_walk(u, loglstar, axes, scale, prior_transform,
     Generic random walk step
     Parameters
     ----------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the initial sample. **This is a copy of an existing live
         point.**
 
@@ -185,7 +185,7 @@ def generic_random_walk(u, loglstar, axes, scale, prior_transform,
 
     Returns
     -------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the final proposed point within the unit cube.
 
     v : `~numpy.ndarray` with shape (ndim,)
@@ -490,7 +490,7 @@ def sample_slice(args):
 
     Parameters
     ----------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the initial sample. **This is a copy of an existing live
         point.**
 
@@ -517,7 +517,7 @@ def sample_slice(args):
 
     Returns
     -------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the final proposed point within the unit cube.
 
     v : `~numpy.ndarray` with shape (ndim,)
@@ -599,7 +599,7 @@ def sample_rslice(args):
 
     Parameters
     ----------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the initial sample. **This is a copy of an existing live
         point.**
 
@@ -625,7 +625,7 @@ def sample_rslice(args):
 
     Returns
     -------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the final proposed point within the unit cube.
 
     v : `~numpy.ndarray` with shape (ndim,)
@@ -706,7 +706,7 @@ def sample_hslice(args):
 
     Parameters
     ----------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the initial sample. **This is a copy of an existing live
         point.**
 
@@ -732,7 +732,7 @@ def sample_hslice(args):
 
     Returns
     -------
-    u : `~numpy.ndarray` with shape (npdim,)
+    u : `~numpy.ndarray` with shape (ndim,)
         Position of the final proposed point within the unit cube.
 
     v : `~numpy.ndarray` with shape (ndim,)


### PR DESCRIPTION
This gets rid of npdim and produces a couple of deprecation warnings.

A couple of decisions I had to make -- I made sure to rename all the npdim= keywords in various classes (other than the top ones like NestedSampler and DynamicNestedSampler) to ndim=. The reason is that I prefer minimize the number of concepts/standard variable names throughout the code.
The consequence of that is that when we release this i don't quite know if restoring checkpoints from previous version will be possible. I don't think it is a big deal, but not everyone may agree.

This is followup from #456


