### PR TITLE
Fix pool docs to clarify the sampler should not get its own args/kwargs

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -470,7 +470,7 @@ when we initialize the pool. When we run dynesty we provide the
 loglikelihood and prior transforms from the pool. This approach minimizes
 the overhead from picking function repeatedly.
 
-If your function has additional arguments that are large, you can also provide
+If your function has additional arguments, you must also provide
 them when initializing the pool::
 
     with Pool(10, loglike, ptform, logl_args=loglike_args) as pool:

--- a/py/dynesty/pool.py
+++ b/py/dynesty/pool.py
@@ -92,7 +92,9 @@ class Pool:
 
     Also note that you have to provide the .loglike/.prior_transform attributes
     from the pool object to the Nested samper rather than your original
-    functions!
+    functions!  Additionally, you should not provide 
+    ``logl_args``/``logl_kwargs`` or ``ptform_args``/``ptform_kwargs`` if you
+    are using the pool, it will be taken care of by the pool itself.
     """
 
     def __init__(self,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request!

Before submitting a PR please take a look at the [CONTRIBUTING.md](CONTRIBUTING.md) page.
-->


### Reference issue

N/A

### What does you PR implement/fix ?

It took me a while to figure this one out.  When trying to use the dynesty  built-in pool helper I kept getting the following traceback:
```
Traceback (most recent call last):
  File "<REDACTED>/dynesty/dynesty.py", line 910, in __call__
    return self.func(np.asarray(x).copy(), *self.args, **self.kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: loglike_cache() takes 1 positional argument but 3 were given
```
it turns out this was happening because the top-level ``__call__` method kept trying to pass in the args, but the pool expects *no* args and kwargs to the log likelihood since it caches them.  I had naively just copied-and-pasted my sampler initialization code and done what the docstring said (updated the ll and ptrans to point to the pool), but didn't realize that the pool would also be taking care of the args and kwargs.

So this PR just clarifies that a bit more in the docs that this is a *requirement* not a "you can if you want to" as it was previously phrased.

A further step might be to actually recognize this failure mode and produce an exception in the initialization process. I figured this doc update is useful regardless, but if that sounds good to others I am happy to make an issue or maybe even a PR to implement it.