### PR TITLE
add missing h in docs front page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ estimate Bayesian posteriors and evidences for large-dimensional
 Installation
 ============
 
-``dynesty`` is compatible wit Python 3.6+. It requires
+``dynesty`` is compatible with Python 3.6+. It requires
 ``numpy`` (for arithmetic), 
 ``scipy`` (for special functions), 
 ``matplotlib`` (for plotting), and 


### PR DESCRIPTION
I noticed this while doing #464 . It's about as trivial a PR as can exist, but I can't un-see it now! :wink: 