### PR TITLE
Replace x.ptp() with np.ptp(x)

### DIFF
--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -66,7 +66,7 @@ def compute_weights(results):
     logwt = results.logwt
     samples_n = results.samples_n
 
-    if logz.ptp() == 0:
+    if np.ptp(logz) == 0:
         # this pathological case can happen if all logl are very small
         # and all logz are very small and the same
         # then the calculation below failse

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -786,7 +786,7 @@ class Sampler:
                         self.added_live = False
                     if current_n_effective > n_effective:
                         stop_iterations = True
-            if self.live_logl.ptp() == 0:
+            if np.ptp(self.live_logl) == 0:
                 warnings.warn(
                     'We have reached the plateau in the likelihood we are'
                     ' stopping sampling')

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -2056,7 +2056,7 @@ def _merge_two(res1, res2, compute_aux=False):
             if nplateau > 1:
                 # the number of live points should not change throughout
                 # the plateau
-                # assert nlive_array[i:][plateau_mask].ptp() == 0
+                # assert np.ptp(nlive_array[i:][plateau_mask]) == 0
                 # TODO currently I disabled this check
 
                 plateau_counter = nplateau


### PR DESCRIPTION
Numpy 2.0 removes the array method `.ptp()` in favour of the function `np.ptp`. This replaces the handful of calls in the code.