### PR TITLE
use pypandoc.convert_text method, fixes a potential error during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ try:
     with open('README.md', 'r') as f:
         txt = f.read()
     txt = re.sub('<[^<]+>', '', txt)
-    long_description = pypandoc.convert(txt, 'rst', 'md')
+    long_description = pypandoc.convert_text(txt, 'rst', 'md')
 except ImportError:
     long_description = open('README.md').read()
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request!

Before submitting a PR please take a look at the [CONTRIBUTING.md](CONTRIBUTING.md) page.
-->


### Reference issue

#492

### What does you PR implement/fix ?

`pypandoc.convert` was deprecated and removed in pypandoc. The usage can be replaced with `pypandoc.convert_text` with no other changes.