### PR TITLE
MAINT: avoid numpy deprecation error in empty intersection

### DIFF
--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -821,7 +821,7 @@ def get_nonbounded(ndim, periodic, reflective):
     and false for periodic/reflective
     """
     if periodic is not None and reflective is not None:
-        if np.intersect1d(periodic, reflective) != 0:
+        if np.intersect1d(periodic, reflective).size > 0:
             raise ValueError("You have specified a parameter as both "
                              "periodic and reflective.")
 


### PR DESCRIPTION
### Reference issue

Closes https://github.com/joshspeagle/dynesty/issues/497

### What does you PR implement/fix ?

Switch to the numpy recommended method to check for an empty array.

cc @segasai @joshspeagle 