### PR TITLE
Fix the treatment of the initial prior volume for likelihoods with -inf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 [Unreleased]
 ### Added
+- The results objects now include the logvol_init attribute with the log of the prior volume at the start of the run. It is zero unless part of the prior has zero likelihood, in which case it is the log of the estimated finite-likelihood prior fraction (fixed by @segasai)
 ### Changed
 ### Fixed
+- Fix the evidence computations for runs where the likelihood is equal to -inf over part of the prior. Previously the initial prior volume estimated during live-point initialization was discarded by the final integral recomputation in the static run_nested(), by jitter_run()/resample_run()/unravel_run() and by merge_runs(), leading to systematically overestimated logz (by up to the log of the inverse finite-likelihood prior fraction) and invalid uncertainties. Now the initial volume is stored in the results (see logvol_init above), used consistently by all evidence reconstructions, and properly combined when merging runs or full-prior batches (fixed by @segasai)
 
 [3.1.0 - 2026-07-17]
 ### Added

--- a/py/dynesty/dynamicsampler.py
+++ b/py/dynesty/dynamicsampler.py
@@ -23,7 +23,7 @@ from .results import Results
 from .utils import (get_seed_sequence, get_print_func, _kld_error,
                     compute_integrals, IteratorResult, IteratorResultShort,
                     RunRecord, get_neff_from_logwt, DelayTimer, save_sampler,
-                    restore_sampler)
+                    restore_sampler, _combine_logvol_inits)
 
 __all__ = [
     "DynamicSampler",
@@ -758,6 +758,12 @@ class DynamicSampler:
         self.new_logl_min, self.new_logl_max = -np.inf, np.inf
         # logl bounds of latest "new" run
 
+        self.logvol_init = 0.
+        # initial log-volume estimate of the combined run; updated
+        # in combine_runs() when a prior-sampled batch is merged in
+        self.new_logvol_init = 0.
+        # initial log-volume estimate of the latest "new" run
+
         # these are set-up during sampling
         self.live_u = None
         self.live_v = None
@@ -876,7 +882,8 @@ class DynamicSampler:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             results = [('niter', self.it - 1), ('ncall', d['nc']),
-                       ('eff', self.eff), ('samples', d['v'])]
+                       ('eff', self.eff), ('samples', d['v']),
+                       ('logvol_init', self.logvol_init)]
             for k in ['id', 'batch', 'it', 'u', 'n']:
                 results.append(('samples_' + k, d[k]))
             for k in [
@@ -1108,6 +1115,7 @@ class DynamicSampler:
                                    bound_enlarge=self.bound_enlarge,
                                    blob=self.blob,
                                    logvol_init=logvol_init)
+            self.logvol_init = logvol_init
             self.bound_list = self.sampler.bound_list
             self.internal_state = DynamicSamplerStatesEnum.LIVEPOINTSINIT
             # Run the sampler internally as a generator.
@@ -1210,8 +1218,10 @@ class DynamicSampler:
                                  proposal_stats=None)
         new_vals = {}
         (new_vals['logwt'], new_vals['logz'], new_vals['logzvar'],
-         new_vals['h']) = compute_integrals(logl=self.saved_run['logl'],
-                                            logvol=self.saved_run['logvol'])
+         new_vals['h']) = compute_integrals(
+             logl=self.saved_run['logl'],
+             logvol=self.saved_run['logvol'],
+             logvol_init=self.logvol_init)
         for curk in ['logwt', 'logz', 'logzvar', 'h']:
             self.saved_run[curk] = new_vals[curk].tolist()
             self.base_run[curk] = new_vals[curk].tolist()
@@ -1461,6 +1471,7 @@ class DynamicSampler:
                                       eff=self.eff,
                                       delta_logz=np.nan,
                                       proposal_stats=None)
+        self.new_logvol_init = batch_sampler.logvol_init
         del self.batch_sampler
         self.batch_sampler = None
 
@@ -1551,10 +1562,22 @@ class DynamicSampler:
                 logl_n = np.inf
                 nlive_n = 0
 
+        if self.new_logl_min == -np.inf:
+            # The new batch was sampled from the whole prior, so its
+            # initial volume estimate is combined with the current one
+            # in the same way as _merge_two() merges independent runs,
+            # weighting by the numbers of prior-sampled live points.
+            nlive_prior = sum(n for n, b in zip(old_batch_nlive,
+                                                old_batch_logl_bounds)
+                              if b[0] == -np.inf)
+            self.logvol_init = _combine_logvol_inits(
+                [self.logvol_init, self.new_logvol_init],
+                [nlive_prior, max(new_d['n'])])
+
         plateau_mode = False
         plateau_counter = 0
         plateau_logdvol = 0
-        logvol = self.sampler.logvol_init
+        logvol = self.logvol_init
         logl_array = np.array(self.saved_run['logl'])
         nlive_array = np.array(self.saved_run['n'])
 
@@ -1589,7 +1612,9 @@ class DynamicSampler:
                                                  saved_d['logl'][-1])
 
         new_logwt, new_logz, new_logzvar, new_h = compute_integrals(
-            logl=self.saved_run['logl'], logvol=self.saved_run['logvol'])
+            logl=self.saved_run['logl'],
+            logvol=self.saved_run['logvol'],
+            logvol_init=self.logvol_init)
         self.saved_run['logwt'].extend(new_logwt.tolist())
         self.saved_run['logz'].extend(new_logz.tolist())
         self.saved_run['logzvar'].extend(new_logzvar.tolist())
@@ -1597,6 +1622,7 @@ class DynamicSampler:
 
         # Reset results.
         self.new_run = None
+        self.new_logvol_init = 0.
         self.new_logl_min, self.new_logl_max = -np.inf, np.inf
 
         # Increment batch counter.

--- a/py/dynesty/sampler.py
+++ b/py/dynesty/sampler.py
@@ -576,7 +576,8 @@ class Sampler:
             results = [('nlive', self.nlive), ('niter', self.it - 1),
                        ('ncall', d['nc']), ('eff', self.eff),
                        ('samples', d['v']), ('blob', d['blob']),
-                       ('proposal_stats', d['proposal_stats'])]
+                       ('proposal_stats', d['proposal_stats']),
+                       ('logvol_init', self.logvol_init)]
             for k in ['id', 'it', 'u']:
                 results.append(('samples_' + k, d[k]))
             for k in ['logwt', 'logl', 'logvol', 'logz']:
@@ -1341,7 +1342,9 @@ class Sampler:
 
             # Here we recompute the integrals using the full run
             new_logwt, new_logz, new_logzvar, new_h = compute_integrals(
-                logl=self.saved_run['logl'], logvol=self.saved_run['logvol'])
+                logl=self.saved_run['logl'],
+                logvol=self.saved_run['logvol'],
+                logvol_init=self.logvol_init)
             self.saved_run['logwt'] = new_logwt.tolist()
             self.saved_run['logz'] = new_logz.tolist()
             self.saved_run['logzvar'] = new_logzvar.tolist()

--- a/py/dynesty/utils.py
+++ b/py/dynesty/utils.py
@@ -754,7 +754,13 @@ _RESULTS_STRUCTURE = [
     ('logwt', 'array', 'Array of log-posterior weights', 'niter'),
     ('eff', 'float', 'Sampling efficiency', None),
     ('nlive', 'int', 'Number of live points for a static run', None),
-    ('logvol', 'array[float]', 'Logvolumes of dead points', 'niter'),
+    ('logvol', 'array[float]',
+     'Log of the prior volume enclosed by each dead point\'s likelihood '
+     'contour', 'niter'),
+    ('logvol_init', 'float',
+     'Log-volume at the start of the run (0 unless part of the prior has '
+     'zero likelihood, in which case it is the log of the estimated '
+     'finite-likelihood prior fraction)', None),
     ('information', 'array[float]', 'Information Integral H', 'niter'),
     ('bound', 'array[object]',
      "the set of bounding objects used to condition proposals for the "
@@ -943,6 +949,30 @@ substituted certain keys in it. It returns a copy object!
         else:
             new_list.append((k, kw_dict[k]))
     return Results(new_list)
+
+
+def _get_logvol_init(res):
+    """
+    Return the log-volume at the start of a run. Results objects
+    created before this key was introduced are assumed to start at
+    unit volume.
+    """
+    if 'logvol_init' in res.keys():
+        return float(res['logvol_init'])
+    return 0.
+
+
+def _combine_logvol_inits(logvol_inits, nlives):
+    """
+    Combine the initial prior-volume estimates of several prior-sampled
+    runs. Each run's estimate of the finite-likelihood prior fraction
+    f_i = exp(logvol_init_i) comes from roughly nlive_i / f_i prior
+    draws yielding nlive_i finite points, so the combined fraction is
+    sum(nlive_i) / sum(nlive_i / f_i).
+    """
+    logvol_inits = np.asarray(logvol_inits, dtype=float)
+    nlives = np.asarray(nlives, dtype=float)
+    return np.log(nlives.sum()) - logsumexp(np.log(nlives) - logvol_inits)
 
 
 def get_nonbounded(ndim, periodic, reflective):
@@ -1387,11 +1417,15 @@ def jitter_run(res, rstate=None, approx=False):
         t_arr[bound[0]:bound[1]] = rorder
 
     # These are the "compression factors" at each iteration. Let's turn
-    # these into associated ln(volumes).
-    logvol = np.log(t_arr).cumsum()
+    # these into associated ln(volumes) starting from the run's initial
+    # volume.
+    logvol_init = _get_logvol_init(res)
+    logvol = logvol_init + np.log(t_arr).cumsum()
 
     (saved_logwt, saved_logz, saved_logzvar,
-     saved_h) = compute_integrals(logl=logl, logvol=logvol)
+     saved_h) = compute_integrals(logl=logl,
+                                  logvol=logvol,
+                                  logvol_init=logvol_init)
 
     # Overwrite items with our new estimates.
     substitute = {
@@ -1406,7 +1440,7 @@ def jitter_run(res, rstate=None, approx=False):
     return new_res
 
 
-def compute_integrals(*, logl, logvol, reweight=None):
+def compute_integrals(*, logl, logvol, reweight=None, logvol_init=0):
     """
     Compute weights, logzs and variances using quadratic estimator.
     Returns logwt, logz, logzvar, h
@@ -1419,22 +1453,27 @@ def compute_integrals(*, logl, logvol, reweight=None):
         array of log volumes
     reweight: array (or None)
         (optional) reweighting array to reweight posterior
+    logvol_init: float
+        (optional) log-volume at the start of the run, i.e. the volume
+        from which the first sample shrinks. It is zero unless part of
+        the prior has zero likelihood, in which case it is the log of
+        the estimated finite-likelihood prior fraction.
     """
 
     loglstar_pad = np.concatenate([[-1.e300], logl])
 
     # we want log(exp(logvol_i)-exp(logvol_(i+1)))
-    # assuming that logvol0 = 0
+    # where the volume before the first sample is exp(logvol_init)
     # log(exp(LV_{i})-exp(LV_{i+1})) =
     # = LV{i} + log(1-exp(LV_{i+1}-LV{i}))
     # = LV_{i+1} - (LV_{i+1} -LV_i) + log(1-exp(LV_{i+1}-LV{i}))
-    dlogvol = np.diff(logvol, prepend=0)
+    dlogvol = np.diff(logvol, prepend=logvol_init)
     logdvol = logvol - dlogvol + np.log1p(-np.exp(dlogvol))
     # logdvol is log(delta(volumes)) i.e. log (X_i-X_{i-1})
     logdvol2 = logdvol + math.log(0.5)
     # These are log(1/2(X_(i+1)-X_i))
 
-    dlogvol = -np.diff(logvol, prepend=0)
+    dlogvol = -np.diff(logvol, prepend=logvol_init)
     # this are delta(log(volumes)) of the run
 
     # These are log((L_i+L_{i_1})*(X_i+1-X_i)/2)
@@ -1623,11 +1662,13 @@ def resample_run(res, rstate=None, return_idx=False):
         # number of live points and can simply be re-ordered.
         samp_n = samples_n[samp_idx]
 
-    # Assign log(volume) to samples.
-    logvol = np.cumsum(np.log(samp_n / (samp_n + 1.)))
+    # Assign log(volume) to samples, starting from the run's initial
+    # volume.
+    logvol_init = _get_logvol_init(res)
+    logvol = logvol_init + np.cumsum(np.log(samp_n / (samp_n + 1.)))
 
     saved_logwt, saved_logz, saved_logzvar, saved_h = compute_integrals(
-        logl=logl, logvol=logvol)
+        logl=logl, logvol=logvol, logvol_init=logvol_init)
 
     # Compute sampling efficiency.
     eff = 100. * len(res.ncall[samp_idx]) / sum(res.ncall[samp_idx])
@@ -1646,6 +1687,7 @@ def resample_run(res, rstate=None, return_idx=False):
                         logwt=np.asarray(saved_logwt),
                         logl=logl,
                         logvol=logvol,
+                        logvol_init=logvol_init,
                         logz=np.asarray(saved_logz),
                         logzerr=np.sqrt(
                             np.maximum(np.asarray(saved_logzvar), 0)),
@@ -1691,7 +1733,10 @@ def reweight_run(res, logp_new, logp_old=None):
     logl = res['logl']
 
     saved_logwt, saved_logz, saved_logzvar, saved_h = compute_integrals(
-        logl=logl, logvol=logvol, reweight=logrwt)
+        logl=logl,
+        logvol=logvol,
+        reweight=logrwt,
+        logvol_init=_get_logvol_init(res))
 
     # Overwrite items with our new estimates.
     substitute = {
@@ -1748,6 +1793,7 @@ def unravel_run(res, print_progress=True):
     # Recreate the nested sampling run for each strand.
     new_res = []
     nstrands = len(np.unique(idxs))
+    logvol_init = _get_logvol_init(res)
     for counter, idx in enumerate(np.unique(idxs)):
         # Select strand `idx`.
         strand = idxs == idx
@@ -1759,21 +1805,22 @@ def unravel_run(res, print_progress=True):
         # shrinking by 1/2). If the final set of live points were added,
         # the expected value of the final live point is a uniform
         # sample and so has an expected value of half the volume
-        # of the final dead point.
+        # of the final dead point. The whole strand starts from the run's
+        # initial volume.
         if added_live:
             niter = nsamps - 1
-            logvol_dead = -math.log(2) * (1. + np.arange(niter))
+            logvol_dead = logvol_init - math.log(2) * (1. + np.arange(niter))
             if niter > 0:
                 logvol_live = logvol_dead[-1] + math.log(0.5)
                 logvol = np.append(logvol_dead, logvol_live)
             else:  # point always live
-                logvol = np.array([math.log(0.5)])
+                logvol = np.array([logvol_init + math.log(0.5)])
         else:
             niter = nsamps
-            logvol = -math.log(2) * (1. + np.arange(niter))
+            logvol = logvol_init - math.log(2) * (1. + np.arange(niter))
 
         saved_logwt, saved_logz, saved_logzvar, saved_h = compute_integrals(
-            logl=logl, logvol=logvol)
+            logl=logl, logvol=logvol, logvol_init=logvol_init)
 
         # Compute sampling efficiency.
         eff = 100. * nsamps / sum(res.ncall[strand])
@@ -1791,6 +1838,7 @@ def unravel_run(res, print_progress=True):
                      logwt=saved_logwt,
                      logl=logl,
                      logvol=logvol,
+                     logvol_init=logvol_init,
                      logz=saved_logz,
                      logzerr=np.sqrt(saved_logzvar),
                      information=saved_h)
@@ -2009,7 +2057,8 @@ def _prepare_for_merge(res):
                     nc=res.ncall,
                     it=res.samples_it,
                     blob=res.blob,
-                    proposal_stats=res.proposal_stats)
+                    proposal_stats=res.proposal_stats,
+                    logvol_init=_get_logvol_init(res))
     nrun = len(run_info['id'])
 
     # Number of live points throughout the run.
@@ -2154,10 +2203,27 @@ def _merge_two(res1, res2, compute_aux=False):
 
         combined_info['n'].append(cur_nlive)
 
+    # Combine the initial volume estimates of the runs that contain
+    # prior-sampled points (see _combine_logvol_inits). Add-on runs
+    # sample above a finite logl bound and carry no information on the
+    # initial volume.
+    init_logvols, init_nlives = [], []
+    for lowedge, info, nlive0 in [(base_lowedge, base_info, base_nlive[0]),
+                                  (new_lowedge, new_info, new_nlive[0])]:
+        if lowedge == -np.inf:
+            init_logvols.append(info['logvol_init'])
+            init_nlives.append(nlive0)
+    if len(init_logvols) == 2:
+        logvol_init = _combine_logvol_inits(init_logvols, init_nlives)
+    elif len(init_logvols) == 1:
+        logvol_init = init_logvols[0]
+    else:
+        logvol_init = 0.
+
     plateau_mode = False
     plateau_counter = 0
     plateau_logdvol = 0
-    logvol = 0.
+    logvol = logvol_init
     logl_array = np.array(combined_info['logl'])
     nlive_array = np.array(combined_info['n'])
     for i, (curl, nlive) in enumerate(zip(logl_array, nlive_array)):
@@ -2193,6 +2259,7 @@ def _merge_two(res1, res2, compute_aux=False):
              samples=np.asarray(combined_info['v']),
              logl=np.asarray(combined_info['logl']),
              logvol=np.asarray(combined_info['logvol']),
+             logvol_init=logvol_init,
              batch_logl_bounds=np.asarray(combined_bounds),
              blob=np.asarray(combined_info['blob']))
 
@@ -2204,7 +2271,8 @@ def _merge_two(res1, res2, compute_aux=False):
 
         (r['logwt'], r['logz'], combined_logzvar,
          r['information']) = compute_integrals(logvol=r['logvol'],
-                                               logl=r['logl'])
+                                               logl=r['logl'],
+                                               logvol_init=logvol_init)
         r['logzerr'] = np.sqrt(np.maximum(combined_logzvar, 0))
 
         # Compute batch information.

--- a/tests/test_logvol_init.py
+++ b/tests/test_logvol_init.py
@@ -1,0 +1,142 @@
+"""
+Regression tests for the treatment of the initial prior volume
+(logvol_init) of runs where part of the prior has zero (-inf)
+likelihood. They cover the final integral recomputation in static
+run_nested(), the jitter_run()/resample_run() realizations and
+merge_runs().
+"""
+import numpy as np
+import pytest
+from scipy.special import logsumexp
+import dynesty
+from dynesty import utils as dyfunc
+from utils import get_rstate, get_printing
+
+printing = get_printing()
+
+# 2-d problem: logl = 0.1 * x0 for x1 < 0.35 and -inf otherwise
+# Z = 0.35 * int_0^1 exp(0.1 x) dx = 0.35 * (e^0.1 - 1) / 0.1
+LOGZ_TRUTH_2D = np.log(0.35 * (np.exp(0.1) - 1) / 0.1)
+
+
+def loglike_2d(x):
+    if x[1] < 0.35:
+        return 0.1 * x[0]
+    return -np.inf
+
+
+def prior_transform(u):
+    return u
+
+
+@pytest.fixture(scope='module')
+def restricted_run():
+    # With a 0.35 finite-likelihood fraction the live-point
+    # initialization takes several attempts (logvol_init < 0) and for
+    # most seeds (including the default one) every live point ends up
+    # with a finite likelihood. Without _LOWL_VAL filler points the
+    # first dead point carries an appreciable likelihood, which is the
+    # configuration where a wrong initial volume maximally biases the
+    # first integration interval.
+    rstate = get_rstate()
+    sampler = dynesty.NestedSampler(loglike_2d,
+                                    prior_transform,
+                                    2,
+                                    nlive=100,
+                                    sample='unif',
+                                    bound='multi',
+                                    rstate=rstate)
+    sampler.run_nested(print_progress=printing)
+    res = sampler.results
+    # make sure the initialization really was restricted
+    assert sampler.logvol_init < -0.5
+    return res
+
+
+def test_static_recompute(restricted_run):
+    # the final recomputation of the integrals in run_nested() must not
+    # discard the restricted initial prior volume
+    assert np.abs(restricted_run['logz'][-1] - LOGZ_TRUTH_2D) < 0.35
+
+
+def test_results_logvol_init_key(restricted_run):
+    # the initial volume must be stored in the results
+    assert restricted_run['logvol_init'] < -0.5
+
+
+@pytest.mark.parametrize('func', [dyfunc.jitter_run, dyfunc.resample_run])
+def test_jitter_resample(restricted_run, func):
+    # realizations of the run must scatter around the true evidence
+    # rather than be systematically shifted by -logvol_init
+    rstate = get_rstate()
+    logzs = np.array([
+        func(restricted_run, rstate=rstate)['logz'][-1] for _ in range(20)
+    ])
+    assert np.abs(logzs.mean() - LOGZ_TRUTH_2D) < 0.35
+
+
+def loglike_1d(x):
+    if x[0] < 0.1:
+        return x[0]
+    return -np.inf
+
+
+def test_merge():
+    # merging runs with a restricted initial prior volume must pool the
+    # initial volumes instead of restarting from unit volume
+    logz_truth = np.log(np.exp(0.1) - 1)
+    rstate = get_rstate()
+    runs = []
+    for i in range(2):
+        sampler = dynesty.NestedSampler(loglike_1d,
+                                        prior_transform,
+                                        1,
+                                        nlive=50,
+                                        sample='unif',
+                                        bound='none',
+                                        rstate=rstate)
+        sampler.run_nested(print_progress=printing)
+        runs.append(sampler.results)
+    merged = dyfunc.merge_runs(runs, print_progress=printing)
+    assert np.abs(merged['logz'][-1] - logz_truth) < 0.5
+    assert merged['logvol_init'] < -1
+
+
+def test_dynamic_batch_combine():
+    # a batch sampled from the whole prior carries its own initial
+    # volume estimate which must be combined with the baseline one
+    # using the same equations as merge_runs()
+    rstate = get_rstate()
+    dns = dynesty.DynamicNestedSampler(loglike_2d,
+                                       prior_transform,
+                                       2,
+                                       sample='unif',
+                                       bound='multi',
+                                       rstate=rstate)
+    for _ in dns.sample_initial(nlive=100, dlogz=0.01):
+        pass
+    lvi_base = dns.logvol_init
+    assert lvi_base < -0.5
+    for _ in dns.sample_batch(nlive_new=50, logl_bounds=(-np.inf, 0.05)):
+        pass
+    lvi_batch = dns.new_logvol_init
+    dns.combine_runs()
+    res = dns.results
+    expected = np.log(150) - logsumexp(
+        [np.log(100) - lvi_base, np.log(50) - lvi_batch])
+    assert np.isclose(res['logvol_init'], expected)
+    assert np.abs(res['logz'][-1] - LOGZ_TRUTH_2D) < 0.35
+
+
+def test_compute_integrals():
+    # with an initial volume X0 the quadrature must integrate over
+    # [X_last, X0] exactly (the likelihood at X0 is padded with ~zero)
+    logvol_init = -1.5
+    logvol = logvol_init + np.log(np.linspace(0.9, 0.01, 30))
+    logl = np.linspace(0., 1., 30)
+    logwt, logz, logzvar, h = dyfunc.compute_integrals(
+        logl=logl, logvol=logvol, logvol_init=logvol_init)
+    x = np.concatenate([[np.exp(logvol_init)], np.exp(logvol)])
+    lik = np.concatenate([[0], np.exp(logl)])
+    expected = np.log(np.sum(0.5 * (lik[1:] + lik[:-1]) * (x[:-1] - x[1:])))
+    assert np.abs(logz[-1] - expected) < 1e-6


### PR DESCRIPTION
When the likelihood is -inf over part of the prior, the live-point initialization estimate fraction and records its logvol_init = -log(iattempt). The progressive integration during sampling uses this correctly, but code paths that reintegrate a finished run assumed the run started at unit prior volume:

- the final recomputation of the integrals at the end of the static
run_nested() 
- jitter_run(), resample_run() and unravel_run(), which rebuilt logvol as cumulative sums starting from zero
- merge_runs()/_merge_two(), which restarted the merged volume walk at logvol
= 0,
- the analogous recomputations in the dynamic sampler  (sample_initial baseline finalization and combine_runs).




In practice the issue is unlikely to affect users unless they are doing manual merge_runs(), and the significant fraction of the prior has logL=-inf

The issue was identified by Claude & Codex, and fix has been developed by me&Claude